### PR TITLE
Add default params to launch example_1.py node

### DIFF
--- a/dcist_launch_system/src/dcist_launch_system/example_1.py
+++ b/dcist_launch_system/src/dcist_launch_system/example_1.py
@@ -14,7 +14,7 @@ class Example1Node(Node):
             type=Parameter.Type.STRING.value,
             description="This is a string",
         )
-        self.declare_parameter("prefix", '', descriptor=param_descriptor)
+        self.declare_parameter("prefix", "", descriptor=param_descriptor)
 
         self.prefix = self.get_parameter("prefix").value
         timer_period_s = 0.5


### PR DESCRIPTION
Jazzy requires params to be declared with a default. @GoldenZephyr not sure if there is a different way you would rather handle this.