### PR TITLE
connect spot executor to omniplanner

### DIFF
--- a/dcist_launch_system/launch/master.launch.yaml
+++ b/dcist_launch_system/launch/master.launch.yaml
@@ -105,6 +105,8 @@ launch:
       remap:
           - from: ~/node_status
             to: /ros_system_monitor/node_diagnostic_collector
+          - from: ~/action_sequence_subscriber
+            to: /omniplanner_node/compiled_plan_out
 
   # Spot state publisher
   - arg: {name: launch_spot_state_publisher, default: 'false'}


### PR DESCRIPTION
@y-veys Here's a topic remapping that will let the omniplanner talk to the spot executor. Previously this remapping wasn't there because it won't work for multiple robots. We still need to do a fair bit of infrastructure work to sanely manage multiple robots getting commands from the planner, but this will work for now