### PR TITLE
set teaser upstream to Nathan's fork to fix installation

### DIFF
--- a/install/packages.yaml
+++ b/install/packages.yaml
@@ -18,7 +18,7 @@ repositories:
   teaserpp: # added by Nathan for Hydra
     type: git
     url: https://github.com/nathanhhughes/TEASER-plusplus.git
-    version: fix/third-party
+    version: fix/third_party
   ros2_numpy: # added by Mason for ROMAN
     type: git
     url: https://github.com/Box-Robotics/ros2_numpy.git


### PR DESCRIPTION
@nathanhhughes @mbpeterson70 This should be the fix for getting teaser to not break clipperpy until the Teaser upstream merges this