### PR TITLE
lower roman global descriptor threshold

### DIFF
--- a/dcist_launch_system/config/bag/roman_lc.yaml
+++ b/dcist_launch_system/config/bag/roman_lc.yaml
@@ -14,4 +14,4 @@ force_rm_lc_roll_pitch: true
 force_rm_upside_down: true
 use_object_bottom_middle: false
 submap_descriptor: mean_semantic
-submap_descriptor_thresh: 0.7
+submap_descriptor_thresh: 0.5

--- a/dcist_launch_system/config/default_params/roman_lc.yaml
+++ b/dcist_launch_system/config/default_params/roman_lc.yaml
@@ -14,4 +14,4 @@ force_rm_lc_roll_pitch: true
 force_rm_upside_down: true
 use_object_bottom_middle: false
 submap_descriptor: mean_semantic
-submap_descriptor_thresh: 0.7
+submap_descriptor_thresh: 0.5

--- a/dcist_launch_system/config/real_spot/roman_lc.yaml
+++ b/dcist_launch_system/config/real_spot/roman_lc.yaml
@@ -14,4 +14,4 @@ force_rm_lc_roll_pitch: true
 force_rm_upside_down: true
 use_object_bottom_middle: false
 submap_descriptor: mean_semantic
-submap_descriptor_thresh: 0.7
+submap_descriptor_thresh: 0.5

--- a/dcist_launch_system/config/real_spot_relocalize/roman_lc.yaml
+++ b/dcist_launch_system/config/real_spot_relocalize/roman_lc.yaml
@@ -14,4 +14,4 @@ force_rm_lc_roll_pitch: true
 force_rm_upside_down: true
 use_object_bottom_middle: false
 submap_descriptor: mean_semantic
-submap_descriptor_thresh: 0.7
+submap_descriptor_thresh: 0.5

--- a/dcist_launch_system/config/relocalize/roman_lc.yaml
+++ b/dcist_launch_system/config/relocalize/roman_lc.yaml
@@ -14,4 +14,4 @@ force_rm_lc_roll_pitch: true
 force_rm_upside_down: true
 use_object_bottom_middle: false
 submap_descriptor: mean_semantic
-submap_descriptor_thresh: 0.7
+submap_descriptor_thresh: 0.5

--- a/dcist_launch_system/config/spot_prior_dsg/roman_lc.yaml
+++ b/dcist_launch_system/config/spot_prior_dsg/roman_lc.yaml
@@ -14,4 +14,4 @@ force_rm_lc_roll_pitch: true
 force_rm_upside_down: true
 use_object_bottom_middle: false
 submap_descriptor: mean_semantic
-submap_descriptor_thresh: 0.7
+submap_descriptor_thresh: 0.5

--- a/dcist_launch_system/config_generation/base_params/roman_lc.yaml
+++ b/dcist_launch_system/config_generation/base_params/roman_lc.yaml
@@ -15,4 +15,4 @@ force_rm_lc_roll_pitch: true
 force_rm_upside_down: true
 use_object_bottom_middle: false
 submap_descriptor: mean_semantic
-submap_descriptor_thresh: 0.7
+submap_descriptor_thresh: 0.5


### PR DESCRIPTION
- enables detecting more loop closures at the expense of more computation