### PR TITLE
Feature/no hm update functors

### DIFF
--- a/dcist_launch_system/config/bag/hydra_multi.yaml
+++ b/dcist_launch_system/config/bag/hydra_multi.yaml
@@ -26,7 +26,8 @@ backend:
   add_objects_to_deformation_graph: false
   optimize_on_lc: true
   enable_node_merging: true
-  update_functors: []
+  update_functors:
+    agents: {type: UpdateAgentsFunctor}
   initial_align:
     type: LoopClosureInitialAlign
     alignment_gnc_alpha: 0.9

--- a/dcist_launch_system/config/default_params/hydra_multi.yaml
+++ b/dcist_launch_system/config/default_params/hydra_multi.yaml
@@ -26,7 +26,8 @@ backend:
   add_objects_to_deformation_graph: false
   optimize_on_lc: true
   enable_node_merging: true
-  update_functors: []
+  update_functors:
+    agents: {type: UpdateAgentsFunctor}
   initial_align:
     type: LoopClosureInitialAlign
     alignment_gnc_alpha: 0.9

--- a/dcist_launch_system/config/real_spot/hydra_multi.yaml
+++ b/dcist_launch_system/config/real_spot/hydra_multi.yaml
@@ -26,7 +26,8 @@ backend:
   add_objects_to_deformation_graph: false
   optimize_on_lc: true
   enable_node_merging: true
-  update_functors: []
+  update_functors:
+    agents: {type: UpdateAgentsFunctor}
   initial_align:
     type: LoopClosureInitialAlign
     alignment_gnc_alpha: 0.9

--- a/dcist_launch_system/config/real_spot_relocalize/hydra_multi.yaml
+++ b/dcist_launch_system/config/real_spot_relocalize/hydra_multi.yaml
@@ -26,7 +26,8 @@ backend:
   add_objects_to_deformation_graph: false
   optimize_on_lc: true
   enable_node_merging: true
-  update_functors: []
+  update_functors:
+    agents: {type: UpdateAgentsFunctor}
   initial_align:
     type: LoopClosureInitialAlign
     alignment_gnc_alpha: 0.9

--- a/dcist_launch_system/config/relocalize/hydra_multi.yaml
+++ b/dcist_launch_system/config/relocalize/hydra_multi.yaml
@@ -26,7 +26,8 @@ backend:
   add_objects_to_deformation_graph: false
   optimize_on_lc: true
   enable_node_merging: true
-  update_functors: []
+  update_functors:
+    agents: {type: UpdateAgentsFunctor}
   initial_align:
     type: LoopClosureInitialAlign
     alignment_gnc_alpha: 0.9

--- a/dcist_launch_system/config/spot_prior_dsg/hydra_multi.yaml
+++ b/dcist_launch_system/config/spot_prior_dsg/hydra_multi.yaml
@@ -26,7 +26,8 @@ backend:
   add_objects_to_deformation_graph: false
   optimize_on_lc: true
   enable_node_merging: true
-  update_functors: []
+  update_functors:
+    agents: {type: UpdateAgentsFunctor}
   initial_align:
     type: LoopClosureInitialAlign
     alignment_gnc_alpha: 0.9

--- a/dcist_launch_system/config_generation/base_params/hydra_multi.yaml
+++ b/dcist_launch_system/config_generation/base_params/hydra_multi.yaml
@@ -27,7 +27,8 @@ backend:
   add_objects_to_deformation_graph: false
   optimize_on_lc: true
   enable_node_merging: true
-  update_functors: []
+  update_functors:
+    agents: {type: UpdateAgentsFunctor}
   initial_align:
     type: LoopClosureInitialAlign
     alignment_gnc_alpha: 0.9


### PR DESCRIPTION
Turns off backend update functors that aren't used in Hydra-Multi to avoid Hydra-Multi crashing for reasons unrelated to the odom to map estimation