### PR TITLE
refactor experiment manifest

### DIFF
--- a/dcist_launch_system/config_generation/experiment_manifest.yaml
+++ b/dcist_launch_system/config_generation/experiment_manifest.yaml
@@ -17,84 +17,31 @@ launch_configs:
     hydra: []
     prior_dsg: []
     hydra_multi: []
-
     transform_publishers: []
 
-    spot_bag:
-        - core
-        - hydra
-        - roman
-        - bag_spot
-        - status
-        - rviz
+    main: [core, status]
+    map: [main, hydra, roman]
+    bag_map: [map, rviz]
+    relocalize: [main, hydra_multi, roman]
+    bag_relocalize: [relocalize, rviz]
+    no_relocalize: [main, transform_publishers]
+    plan_prior: [main, prior_dsg, planning]
 
-    spot_prior_dsg:
-        - core
-        - prior_dsg
-        - sim_spot
-        - planning
-        - status
+    data_collection: [main, spot_real]
 
-    real_spot:
-        - core
-        - hydra
-        - roman
-        - spot_real
-        - status
+    spot_bag: [bag_map, bag_spot]
+    spot_bag_relocalize: [bag_relocalize, bag_spot]
 
-    real_phoenix:
-        - core
-        - hydra
-        - roman
-        - phoenix_real
-        - status
+    real_spot: [map, spot_real]
+    real_spot_relocalize: [relocalize, spot_real]
+    real_spot_no_relocalize: [no_relocalize, spot_real]
 
-    real_spot_relocalize:
-        - core
-        - hydra_multi
-        - roman
-        - spot_real
-        - status
+    real_phoenix: [map, phoenix_real]
+    real_phoenix_relocalize: [relocalize, phoenix_real]
+    real_phoenix_no_relocalize: [no_relocalize]
 
-    real_phoenix_relocalize:
-        - core
-        - hydra_multi
-        - roman
-        - phoenix_real
-        - status
-
-    data_collection:
-        - core
-        - spot_real
-        - status
-
-    spot_bag_relocalize:
-        - core
-        - hydra_multi
-        - roman
-        - bag_spot
-        - status
-        - rviz
-
-    base_station:
-        - core
-        - prior_dsg
-        - planning
-        - status
-        - multi_status
-
-    real_spot_no_relocalize: 
-        - core
-        - spot_real 
-        - status
-        - transform_publishers
-
-    real_phoenix_no_relocalize: 
-        - core
-        #- phoenix_real 
-        - status
-        - transform_publishers
-
+    spot_prior_dsg: [plan_prior, sim_spot]
+    base_station: [plan_prior, multi_status]
 
 # Configs build the set of rosparams that will be loaded
 configs:
@@ -105,7 +52,7 @@ configs:
     spot_prior_dsg: []
     real_spot: []
     real_phoenix: []
- 
+
     relocalize: []
 
     real_spot_relocalize: [real_spot, relocalize]
@@ -116,50 +63,54 @@ configs:
 # launch files
 experiments:
 
-    spot_bag:
-        launch_config: spot_bag
-        config: [bag]
+    data_collection:
+        launch_config: data_collection
+        config: [real_spot]
 
     spot_prior_dsg:
         launch_config: spot_prior_dsg
         config: [spot_prior_dsg]
 
-    real_spot:
-        launch_config: real_spot
-        config: [real_spot]
+    base_station:
+        launch_config: base_station
+        config: [default_params]
 
-    real_phoenix:
-        launch_config: real_phoenix
-        config: [real_phoenix]
-
-    data_collection:
-        launch_config: data_collection
-        config: [real_spot]
+    spot_bag:
+        launch_config: spot_bag
+        config: [bag]
 
     spot_bag_relocalize:
         launch_config: spot_bag_relocalize
         config: [relocalize]
 
-    base_station:
-        launch_config: base_station
-        config: [default_params]
+    real_spot:
+        launch_config: real_spot
+        config: [real_spot]
 
     real_spot_relocalize:
         launch_config: real_spot_relocalize
-        config: [real_spot_relocalize]
+        config: [real_spot_relocalize, apollo_relocalize]
 
     real_spot_no_relocalize:
         launch_config: real_spot_no_relocalize
         config: [real_spot_relocalize]
 
-    real_phoenix_no_relocalize:
-        launch_config: real_phoenix_no_relocalize
+    real_phoenix:
+        launch_config: real_phoenix
         config: [real_phoenix]
 
     real_phoenix_relocalize:
         launch_config: real_phoenix_relocalize
         config: [real_phoenix_relocalize]
 
-    apollo_relocalize:
-        launch_config: real_spot_relocalize
-        config: [apollo_relocalize]
+    real_phoenix_no_relocalize:
+        launch_config: no_relocalize
+        config: [real_phoenix]
+
+    bag_phoenix:
+        launch_config: bag_map
+        config: [real_phoenix]
+
+    bag_phoenix_relocalize:
+        launch_config: bag_relocalize
+        config: [real_phoenix]

--- a/dcist_launch_system/tmux/autogenerated/bag_phoenix-real_phoenix.yaml
+++ b/dcist_launch_system/tmux/autogenerated/bag_phoenix-real_phoenix.yaml
@@ -5,10 +5,10 @@ nodes_to_monitor:
   fastsam: {}
   roman_map: {}
   roman_lc: {}
-  phoenix_executor: {}
+  nlu_rviz_panel: {}
 session_name: adt4_system
 suppress_history: false
-environment: {sim_time: $ADT4_SIM_TIME, ADT4_PRIOR_MAP: $ADT4_PRIOR_MAP, ADT4_OUTPUT_DIR: $ADT4_OUTPUT_DIR, ADT4_MONITOR_CONFIG: "{nodes_to_track: {dsg_saver: {}, fastsam: {}, hydra: {external_monitor: {type: JsonMonitor}}, phoenix_executor: {}, roman_lc: {}, roman_map: {}}}", ADT4_ROBOT_NAME: $ADT4_ROBOT_NAME, config: real_phoenix, logging_key: real_phoenix-real_phoenix}
+environment: {sim_time: $ADT4_SIM_TIME, ADT4_PRIOR_MAP: $ADT4_PRIOR_MAP, ADT4_OUTPUT_DIR: $ADT4_OUTPUT_DIR, ADT4_MONITOR_CONFIG: "{nodes_to_track: {dsg_saver: {}, fastsam: {}, hydra: {external_monitor: {type: JsonMonitor}}, nlu_rviz_panel: {}, roman_lc: {}, roman_map: {}}}", ADT4_ROBOT_NAME: $ADT4_ROBOT_NAME, config: real_phoenix, logging_key: bag_phoenix-real_phoenix}
 options:
   default-command: /bin/zsh
 windows:
@@ -40,9 +40,7 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_fastsam:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_roman_map:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_roman_lc:=true
-  - window_name: real_phoenix
+  - window_name: rviz
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
-    panes:
-      - "source ${ADT4_WS}/install/setup.zsh && ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_zed:=true"
-      - sleep 5; tmux send-keys -t real_phoenix.2 "ros2 launch mit_launch gauss_mppi_only.launch.yaml" C-m
-      - "cd ${ADT4_PHX_ROOT} && phx run"
+    panes: [ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_rviz:=true]

--- a/dcist_launch_system/tmux/autogenerated/bag_phoenix_relocalize-real_phoenix.yaml
+++ b/dcist_launch_system/tmux/autogenerated/bag_phoenix_relocalize-real_phoenix.yaml
@@ -1,14 +1,13 @@
 nodes_to_monitor:
-  dsg_saver: {}
-  hydra:
+  hydra_multi:
     external_monitor: {type: JsonMonitor}
   fastsam: {}
   roman_map: {}
   roman_lc: {}
-  phoenix_executor: {}
+  nlu_rviz_panel: {}
 session_name: adt4_system
 suppress_history: false
-environment: {sim_time: $ADT4_SIM_TIME, ADT4_PRIOR_MAP: $ADT4_PRIOR_MAP, ADT4_OUTPUT_DIR: $ADT4_OUTPUT_DIR, ADT4_MONITOR_CONFIG: "{nodes_to_track: {dsg_saver: {}, fastsam: {}, hydra: {external_monitor: {type: JsonMonitor}}, phoenix_executor: {}, roman_lc: {}, roman_map: {}}}", ADT4_ROBOT_NAME: $ADT4_ROBOT_NAME, config: real_phoenix, logging_key: real_phoenix-real_phoenix}
+environment: {sim_time: $ADT4_SIM_TIME, ADT4_PRIOR_MAP: $ADT4_PRIOR_MAP, ADT4_OUTPUT_DIR: $ADT4_OUTPUT_DIR, ADT4_MONITOR_CONFIG: "{nodes_to_track: {fastsam: {}, hydra_multi: {external_monitor: {type: JsonMonitor}}, nlu_rviz_panel: {}, roman_lc: {}, roman_map: {}}}", ADT4_ROBOT_NAME: $ADT4_ROBOT_NAME, config: real_phoenix, logging_key: bag_phoenix_relocalize-real_phoenix}
 options:
   default-command: /bin/zsh
 windows:
@@ -24,15 +23,13 @@ windows:
     layout: tiled
     panes:
       - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
-  - window_name: hydra
+  - window_name: hydra_multi
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
     panes:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_semantic_inference:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_hydra:=true
-      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_hydra_visualizer:=true
-      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_dsg_saver:=true
-      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_static_map_to_robot_map:=true
+      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_hydra_multi:=true
   - window_name: roman
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -40,9 +37,7 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_fastsam:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_roman_map:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_roman_lc:=true
-  - window_name: real_phoenix
+  - window_name: rviz
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
-    panes:
-      - "source ${ADT4_WS}/install/setup.zsh && ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_zed:=true"
-      - sleep 5; tmux send-keys -t real_phoenix.2 "ros2 launch mit_launch gauss_mppi_only.launch.yaml" C-m
-      - "cd ${ADT4_PHX_ROOT} && phx run"
+    panes: [ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_rviz:=true]

--- a/dcist_launch_system/tmux/autogenerated/base_station-default_params.yaml
+++ b/dcist_launch_system/tmux/autogenerated/base_station-default_params.yaml
@@ -15,6 +15,11 @@ windows:
       - ros2 run rmw_zenoh_cpp rmw_zenohd
       - python3 $ADT4_WS/src/awesome_dcist_t4/dcist_launch_system/scripts/show_environment.py
       - "ros2 service call /${ADT4_ROBOT_NAME}/shutdown std_srvs/Empty && tmux send-keys -t roman.1 C-c \\"
+  - window_name: status
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes:
+      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
   - window_name: prior_dsg
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -28,11 +33,6 @@ windows:
     panes:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_rviz:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_omniplanner:=true
-  - window_name: status
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes:
-      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
   - window_name: status
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled

--- a/dcist_launch_system/tmux/autogenerated/data_collection-real_spot.yaml
+++ b/dcist_launch_system/tmux/autogenerated/data_collection-real_spot.yaml
@@ -13,6 +13,11 @@ windows:
       - ros2 run rmw_zenoh_cpp rmw_zenohd
       - python3 $ADT4_WS/src/awesome_dcist_t4/dcist_launch_system/scripts/show_environment.py
       - "ros2 service call /${ADT4_ROBOT_NAME}/shutdown std_srvs/Empty && tmux send-keys -t roman.1 C-c \\"
+  - window_name: status
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes:
+      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
   - window_name: real_spot
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -22,8 +27,3 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_driver:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_decompression:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_zed:=true
-  - window_name: status
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes:
-      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'

--- a/dcist_launch_system/tmux/autogenerated/real_phoenix_relocalize-real_phoenix_relocalize.yaml
+++ b/dcist_launch_system/tmux/autogenerated/real_phoenix_relocalize-real_phoenix_relocalize.yaml
@@ -18,6 +18,11 @@ windows:
       - ros2 run rmw_zenoh_cpp rmw_zenohd
       - python3 $ADT4_WS/src/awesome_dcist_t4/dcist_launch_system/scripts/show_environment.py
       - "ros2 service call /${ADT4_ROBOT_NAME}/shutdown std_srvs/Empty && tmux send-keys -t roman.1 C-c \\"
+  - window_name: status
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes:
+      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
   - window_name: hydra_multi
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -38,8 +43,3 @@ windows:
       - "source ${ADT4_WS}/install/setup.zsh && ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_zed:=true"
       - sleep 5; tmux send-keys -t real_phoenix.2 "ros2 launch mit_launch gauss_mppi_only.launch.yaml" C-m
       - "cd ${ADT4_PHX_ROOT} && phx run"
-  - window_name: status
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes:
-      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'

--- a/dcist_launch_system/tmux/autogenerated/real_spot-real_spot.yaml
+++ b/dcist_launch_system/tmux/autogenerated/real_spot-real_spot.yaml
@@ -19,6 +19,11 @@ windows:
       - ros2 run rmw_zenoh_cpp rmw_zenohd
       - python3 $ADT4_WS/src/awesome_dcist_t4/dcist_launch_system/scripts/show_environment.py
       - "ros2 service call /${ADT4_ROBOT_NAME}/shutdown std_srvs/Empty && tmux send-keys -t roman.1 C-c \\"
+  - window_name: status
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes:
+      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
   - window_name: hydra
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -44,8 +49,3 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_driver:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_decompression:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_zed:=true
-  - window_name: status
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes:
-      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'

--- a/dcist_launch_system/tmux/autogenerated/real_spot_no_relocalize-real_spot_relocalize.yaml
+++ b/dcist_launch_system/tmux/autogenerated/real_spot_no_relocalize-real_spot_relocalize.yaml
@@ -13,15 +13,6 @@ windows:
       - ros2 run rmw_zenoh_cpp rmw_zenohd
       - python3 $ADT4_WS/src/awesome_dcist_t4/dcist_launch_system/scripts/show_environment.py
       - "ros2 service call /${ADT4_ROBOT_NAME}/shutdown std_srvs/Empty && tmux send-keys -t roman.1 C-c \\"
-  - window_name: real_spot
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes:
-      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_executor:=true
-      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_state_publisher:=true
-      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_driver:=true
-      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_decompression:=true
-      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_zed:=true
   - window_name: status
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -31,3 +22,12 @@ windows:
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
     panes: [ros2 run tf2_ros static_transform_publisher 0 0 0 0 0 0 map $ADT4_ROBOT_NAME/map, ros2 run tf2_ros static_transform_publisher 0 0 0 0 0 0 $ADT4_ROBOT_NAME/map $ADT4_ROBOT_NAME/odom]
+  - window_name: real_spot
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes:
+      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_executor:=true
+      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_state_publisher:=true
+      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_driver:=true
+      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_decompression:=true
+      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_zed:=true

--- a/dcist_launch_system/tmux/autogenerated/real_spot_relocalize-apollo_relocalize.yaml
+++ b/dcist_launch_system/tmux/autogenerated/real_spot_relocalize-apollo_relocalize.yaml
@@ -7,7 +7,7 @@ nodes_to_monitor:
   spot_executor: {}
 session_name: adt4_system
 suppress_history: false
-environment: {sim_time: $ADT4_SIM_TIME, ADT4_PRIOR_MAP: $ADT4_PRIOR_MAP, ADT4_OUTPUT_DIR: $ADT4_OUTPUT_DIR, ADT4_MONITOR_CONFIG: "{nodes_to_track: {fastsam: {}, hydra_multi: {external_monitor: {type: JsonMonitor}}, roman_lc: {}, roman_map: {}, spot_executor: {}}}", ADT4_ROBOT_NAME: $ADT4_ROBOT_NAME, config: apollo_relocalize, logging_key: apollo_relocalize-apollo_relocalize}
+environment: {sim_time: $ADT4_SIM_TIME, ADT4_PRIOR_MAP: $ADT4_PRIOR_MAP, ADT4_OUTPUT_DIR: $ADT4_OUTPUT_DIR, ADT4_MONITOR_CONFIG: "{nodes_to_track: {fastsam: {}, hydra_multi: {external_monitor: {type: JsonMonitor}}, roman_lc: {}, roman_map: {}, spot_executor: {}}}", ADT4_ROBOT_NAME: $ADT4_ROBOT_NAME, config: apollo_relocalize, logging_key: real_spot_relocalize-apollo_relocalize}
 options:
   default-command: /bin/zsh
 windows:
@@ -18,6 +18,11 @@ windows:
       - ros2 run rmw_zenoh_cpp rmw_zenohd
       - python3 $ADT4_WS/src/awesome_dcist_t4/dcist_launch_system/scripts/show_environment.py
       - "ros2 service call /${ADT4_ROBOT_NAME}/shutdown std_srvs/Empty && tmux send-keys -t roman.1 C-c \\"
+  - window_name: status
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes:
+      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
   - window_name: hydra_multi
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -41,8 +46,3 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_driver:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_decompression:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_zed:=true
-  - window_name: status
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes:
-      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'

--- a/dcist_launch_system/tmux/autogenerated/real_spot_relocalize-real_spot_relocalize.yaml
+++ b/dcist_launch_system/tmux/autogenerated/real_spot_relocalize-real_spot_relocalize.yaml
@@ -18,6 +18,11 @@ windows:
       - ros2 run rmw_zenoh_cpp rmw_zenohd
       - python3 $ADT4_WS/src/awesome_dcist_t4/dcist_launch_system/scripts/show_environment.py
       - "ros2 service call /${ADT4_ROBOT_NAME}/shutdown std_srvs/Empty && tmux send-keys -t roman.1 C-c \\"
+  - window_name: status
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes:
+      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
   - window_name: hydra_multi
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -41,8 +46,3 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_driver:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_decompression:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_zed:=true
-  - window_name: status
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes:
-      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'

--- a/dcist_launch_system/tmux/autogenerated/spot_bag-bag.yaml
+++ b/dcist_launch_system/tmux/autogenerated/spot_bag-bag.yaml
@@ -5,8 +5,8 @@ nodes_to_monitor:
   fastsam: {}
   roman_map: {}
   roman_lc: {}
-  spot_executor: {}
   nlu_rviz_panel: {}
+  spot_executor: {}
 session_name: adt4_system
 suppress_history: false
 environment: {sim_time: $ADT4_SIM_TIME, ADT4_PRIOR_MAP: $ADT4_PRIOR_MAP, ADT4_OUTPUT_DIR: $ADT4_OUTPUT_DIR, ADT4_MONITOR_CONFIG: "{nodes_to_track: {dsg_saver: {}, fastsam: {}, hydra: {external_monitor: {type: JsonMonitor}}, nlu_rviz_panel: {}, roman_lc: {}, roman_map: {}, spot_executor: {}}}", ADT4_ROBOT_NAME: $ADT4_ROBOT_NAME, config: bag, logging_key: spot_bag-bag}
@@ -20,6 +20,11 @@ windows:
       - ros2 run rmw_zenoh_cpp rmw_zenohd
       - python3 $ADT4_WS/src/awesome_dcist_t4/dcist_launch_system/scripts/show_environment.py
       - "ros2 service call /${ADT4_ROBOT_NAME}/shutdown std_srvs/Empty && tmux send-keys -t roman.1 C-c \\"
+  - window_name: status
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes:
+      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
   - window_name: hydra
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -36,6 +41,10 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_fastsam:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_roman_map:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_roman_lc:=true
+  - window_name: rviz
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes: [ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_rviz:=true]
   - window_name: bag_spot
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -43,12 +52,3 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_executor:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_state_publisher:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_decompression:=true
-  - window_name: status
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes:
-      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
-  - window_name: rviz
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes: [ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_rviz:=true]

--- a/dcist_launch_system/tmux/autogenerated/spot_bag_relocalize-relocalize.yaml
+++ b/dcist_launch_system/tmux/autogenerated/spot_bag_relocalize-relocalize.yaml
@@ -4,8 +4,8 @@ nodes_to_monitor:
   fastsam: {}
   roman_map: {}
   roman_lc: {}
-  spot_executor: {}
   nlu_rviz_panel: {}
+  spot_executor: {}
 session_name: adt4_system
 suppress_history: false
 environment: {sim_time: $ADT4_SIM_TIME, ADT4_PRIOR_MAP: $ADT4_PRIOR_MAP, ADT4_OUTPUT_DIR: $ADT4_OUTPUT_DIR, ADT4_MONITOR_CONFIG: "{nodes_to_track: {fastsam: {}, hydra_multi: {external_monitor: {type: JsonMonitor}}, nlu_rviz_panel: {}, roman_lc: {}, roman_map: {}, spot_executor: {}}}", ADT4_ROBOT_NAME: $ADT4_ROBOT_NAME, config: relocalize, logging_key: spot_bag_relocalize-relocalize}
@@ -19,6 +19,11 @@ windows:
       - ros2 run rmw_zenoh_cpp rmw_zenohd
       - python3 $ADT4_WS/src/awesome_dcist_t4/dcist_launch_system/scripts/show_environment.py
       - "ros2 service call /${ADT4_ROBOT_NAME}/shutdown std_srvs/Empty && tmux send-keys -t roman.1 C-c \\"
+  - window_name: status
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes:
+      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
   - window_name: hydra_multi
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -33,6 +38,10 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_fastsam:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_roman_map:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_roman_lc:=true
+  - window_name: rviz
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes: [ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_rviz:=true]
   - window_name: bag_spot
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -40,12 +49,3 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_executor:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_state_publisher:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_camera_decompression:=true
-  - window_name: status
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes:
-      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
-  - window_name: rviz
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes: [ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_rviz:=true]

--- a/dcist_launch_system/tmux/autogenerated/spot_prior_dsg-spot_prior_dsg.yaml
+++ b/dcist_launch_system/tmux/autogenerated/spot_prior_dsg-spot_prior_dsg.yaml
@@ -1,8 +1,8 @@
 nodes_to_monitor:
   dsg_saver: {}
-  spot_executor: {}
   omniplanner: {}
   nlu_rviz_panel: {}
+  spot_executor: {}
 session_name: adt4_system
 suppress_history: false
 environment: {sim_time: $ADT4_SIM_TIME, ADT4_PRIOR_MAP: $ADT4_PRIOR_MAP, ADT4_OUTPUT_DIR: $ADT4_OUTPUT_DIR, ADT4_MONITOR_CONFIG: "{nodes_to_track: {dsg_saver: {}, nlu_rviz_panel: {}, omniplanner: {}, spot_executor: {}}}", ADT4_ROBOT_NAME: $ADT4_ROBOT_NAME, config: spot_prior_dsg, logging_key: spot_prior_dsg-spot_prior_dsg}
@@ -16,6 +16,11 @@ windows:
       - ros2 run rmw_zenoh_cpp rmw_zenohd
       - python3 $ADT4_WS/src/awesome_dcist_t4/dcist_launch_system/scripts/show_environment.py
       - "ros2 service call /${ADT4_ROBOT_NAME}/shutdown std_srvs/Empty && tmux send-keys -t roman.1 C-c \\"
+  - window_name: status
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes:
+      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'
   - window_name: prior_dsg
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -23,6 +28,12 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_scene_graph_publisher:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_hydra_visualizer:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_dsg_saver:=true
+  - window_name: planning
+    shell_command_before: source ${ADT4_WS}/install/setup.zsh
+    layout: tiled
+    panes:
+      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_rviz:=true
+      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_omniplanner:=true
   - window_name: sim_spot
     shell_command_before: source ${ADT4_WS}/install/setup.zsh
     layout: tiled
@@ -31,14 +42,3 @@ windows:
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_spot_state_publisher:=true
       - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_static_map_to_robot_map:=true launch_static_robot_map_to_odom:=true
       - ros2 run teleop_twist_keyboard teleop_twist_keyboard --ros-args -r /cmd_vel:=/$ADT4_ROBOT_NAME/spot_executor_node/cmd_vel
-  - window_name: planning
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes:
-      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_rviz:=true
-      - ros2 launch dcist_launch_system master.launch.yaml conf_name:=$config sim_time:=$sim_time robot_name:=$ADT4_ROBOT_NAME launch_omniplanner:=true
-  - window_name: status
-    shell_command_before: source ${ADT4_WS}/install/setup.zsh
-    layout: tiled
-    panes:
-      - ros2 run ros_system_monitor ros_system_monitor --params $ADT4_MONITOR_CONFIG --name $ADT4_ROBOT_NAME --ros-args -r __ns:=/$ADT4_ROBOT_NAME -r '~/table_out:=/global/ros_system_monitor/table_in'


### PR DESCRIPTION
Went to go add new husky experiments and realized we hadn't cleaned up the experiment manifest in a while. Most of the changes are because the status window is moved earlier in the tmux window order. Hopefully the grouping between "what we're running" and "what robot platform we're running it on" is clearer now