### PR TITLE
Better Spot TFs

### DIFF
--- a/dcist_launch_system/recording/spot_topics.txt
+++ b/dcist_launch_system/recording/spot_topics.txt
@@ -1,6 +1,7 @@
 /tf
 /tf_static
 /${ADT4_ROBOT_NAME}/joint_states
+/${ADT4_ROBOT_NAME}/odom
 /${ADT4_ROBOT_NAME}/rtcm
 /${ADT4_ROBOT_NAME}/fix
 /${ADT4_ROBOT_NAME}/${ADT4_ROBOT_NAME}_zed/imu/data


### PR DESCRIPTION
Bumps `spot_tools` to point to TF fixes in the sensor driver, and publishes and records odometry from spot