### PR TITLE
Fix Prior Map as Prior

### DIFF
--- a/dcist_launch_system/config/apollo_relocalize/hydra_multi.yaml
+++ b/dcist_launch_system/config/apollo_relocalize/hydra_multi.yaml
@@ -12,6 +12,8 @@ robots:
         type: FileDGraphInput
         dgrf_path: $<env ADT4_PRIOR_MAP>/hydra/backend/deformation_graph.dgrf
         include_priors: true
+        fix_as_prior: true
+        prior_variance: 1.0e-6
   - type: RosUnitInterface
     robot_id: 0
     rate: 10.0

--- a/dcist_launch_system/config/classic/hydra_multi.yaml
+++ b/dcist_launch_system/config/classic/hydra_multi.yaml
@@ -12,6 +12,8 @@ robots:
         type: FileDGraphInput
         dgrf_path: $<env ADT4_PRIOR_MAP>/hydra/backend/deformation_graph.dgrf
         include_priors: true
+        fix_as_prior: true
+        prior_variance: 1.0e-6
   - type: RosUnitInterface
     robot_id: 0
     rate: 10.0

--- a/dcist_launch_system/config/default/hydra_multi.yaml
+++ b/dcist_launch_system/config/default/hydra_multi.yaml
@@ -12,6 +12,8 @@ robots:
         type: FileDGraphInput
         dgrf_path: $<env ADT4_PRIOR_MAP>/hydra/backend/deformation_graph.dgrf
         include_priors: true
+        fix_as_prior: true
+        prior_variance: 1.0e-6
   - type: RosUnitInterface
     robot_id: 0
     rate: 10.0

--- a/dcist_launch_system/config/prior_dsg/hydra_multi.yaml
+++ b/dcist_launch_system/config/prior_dsg/hydra_multi.yaml
@@ -12,6 +12,8 @@ robots:
         type: FileDGraphInput
         dgrf_path: $<env ADT4_PRIOR_MAP>/hydra/backend/deformation_graph.dgrf
         include_priors: true
+        fix_as_prior: true
+        prior_variance: 1.0e-6
   - type: RosUnitInterface
     robot_id: 0
     rate: 10.0

--- a/dcist_launch_system/config/relocalize/hydra_multi.yaml
+++ b/dcist_launch_system/config/relocalize/hydra_multi.yaml
@@ -12,6 +12,8 @@ robots:
         type: FileDGraphInput
         dgrf_path: $<env ADT4_PRIOR_MAP>/hydra/backend/deformation_graph.dgrf
         include_priors: true
+        fix_as_prior: true
+        prior_variance: 1.0e-6
   - type: RosUnitInterface
     robot_id: 0
     rate: 10.0

--- a/dcist_launch_system/config_generation/base_params/hydra_multi.yaml
+++ b/dcist_launch_system/config_generation/base_params/hydra_multi.yaml
@@ -13,6 +13,8 @@ robots:
         type: FileDGraphInput
         dgrf_path: $<env ADT4_PRIOR_MAP>/hydra/backend/deformation_graph.dgrf
         include_priors: true
+        fix_as_prior: true
+        prior_variance: 1.0e-6
   - type: RosUnitInterface
     robot_id: 0
     rate: 10.0


### PR DESCRIPTION
@mbpeterson70 still need to double check this does what I think and relocalization still works, this is the rough sketch for forcing nodes as priors. Caveats:
- This will add two identical priors on the first node of the prior scene graph (which should be fine), if we flip `include_priors` to false we'll get uniform priors on every trajectory pose in the prior map
- I don't exactly know how the control points and deformation factors for the prior map will behave in the optimization (I'm pretty sure they won't move though)