### PR TITLE
turn down hydra multi verbosity

### DIFF
--- a/dcist_launch_system/config/apollo_relocalize/hydra_multi.yaml
+++ b/dcist_launch_system/config/apollo_relocalize/hydra_multi.yaml
@@ -1,3 +1,5 @@
+enable_pgmo_logging: false
+disable_timer_output: false
 world_frame: map
 robots:
   - type: UnitInterface
@@ -31,6 +33,8 @@ backend:
   anchor_robot_id: -1
   optimize_on_lc: true
   enable_node_merging: true
+  external_loop_closures:
+    max_time_difference: 1.0
   update_functors:
     agents: {type: UpdateAgentsFunctor}
   initial_align:

--- a/dcist_launch_system/config/classic/hydra_multi.yaml
+++ b/dcist_launch_system/config/classic/hydra_multi.yaml
@@ -1,3 +1,5 @@
+enable_pgmo_logging: false
+disable_timer_output: false
 world_frame: map
 robots:
   - type: UnitInterface
@@ -31,6 +33,8 @@ backend:
   anchor_robot_id: -1
   optimize_on_lc: true
   enable_node_merging: true
+  external_loop_closures:
+    max_time_difference: 1.0
   update_functors:
     agents: {type: UpdateAgentsFunctor}
   initial_align:

--- a/dcist_launch_system/config/default/hydra_multi.yaml
+++ b/dcist_launch_system/config/default/hydra_multi.yaml
@@ -1,3 +1,5 @@
+enable_pgmo_logging: false
+disable_timer_output: false
 world_frame: map
 robots:
   - type: UnitInterface
@@ -31,6 +33,8 @@ backend:
   anchor_robot_id: -1
   optimize_on_lc: true
   enable_node_merging: true
+  external_loop_closures:
+    max_time_difference: 1.0
   update_functors:
     agents: {type: UpdateAgentsFunctor}
   initial_align:

--- a/dcist_launch_system/config/prior_dsg/hydra_multi.yaml
+++ b/dcist_launch_system/config/prior_dsg/hydra_multi.yaml
@@ -1,3 +1,5 @@
+enable_pgmo_logging: false
+disable_timer_output: false
 world_frame: map
 robots:
   - type: UnitInterface
@@ -31,6 +33,8 @@ backend:
   anchor_robot_id: -1
   optimize_on_lc: true
   enable_node_merging: true
+  external_loop_closures:
+    max_time_difference: 1.0
   update_functors:
     agents: {type: UpdateAgentsFunctor}
   initial_align:

--- a/dcist_launch_system/config/relocalize/hydra_multi.yaml
+++ b/dcist_launch_system/config/relocalize/hydra_multi.yaml
@@ -1,3 +1,5 @@
+enable_pgmo_logging: false
+disable_timer_output: false
 world_frame: map
 robots:
   - type: UnitInterface
@@ -31,6 +33,8 @@ backend:
   anchor_robot_id: -1
   optimize_on_lc: true
   enable_node_merging: true
+  external_loop_closures:
+    max_time_difference: 1.0
   update_functors:
     agents: {type: UpdateAgentsFunctor}
   initial_align:

--- a/dcist_launch_system/config_generation/base_params/hydra_multi.yaml
+++ b/dcist_launch_system/config_generation/base_params/hydra_multi.yaml
@@ -1,4 +1,6 @@
 ---
+enable_pgmo_logging: false
+disable_timer_output: false
 world_frame: map
 robots:
   - type: UnitInterface
@@ -32,6 +34,8 @@ backend:
   anchor_robot_id: -1
   optimize_on_lc: true
   enable_node_merging: true
+  external_loop_closures:
+    max_time_difference: 1.0
   update_functors:
     agents: {type: UpdateAgentsFunctor}
   initial_align:

--- a/dcist_launch_system/launch/master.launch.yaml
+++ b/dcist_launch_system/launch/master.launch.yaml
@@ -133,7 +133,7 @@ launch:
       args: >
         --config-utilities-var robot_name=$(var robot_name)
         --config-utilities-file $(find-pkg-share dcist_launch_system)/config/$(var conf_name)/hydra_multi.yaml
-        --config-utilities-yaml {glog_level: 0, glog_verbosity: 5}
+        --config-utilities-yaml {glog_level: 0, glog_verbosity: 0}
         --config-utilities-yaml {log_path: $(var output_dir)/hydra_multi, output: {use_timestamp: false, overwrite: true}}
 
   # Hydra-Multi Visualizer


### PR DESCRIPTION
This should be safe to merge, it actually doesn't do anything except decrease the amount of printouts from Hydra-Multi so that we can actually see what's going on (the other parameter is just to make it easier to edit the value if we want to tomorrow, 1 second is the current default)