### PR TITLE
Add Doodle Labs Mesh Rider radio support

### DIFF
--- a/dcist_launch_system/docs/fleet-adt4-user-guide.md
+++ b/dcist_launch_system/docs/fleet-adt4-user-guide.md
@@ -251,7 +251,7 @@ machines:
     addresses:
       mit_wifi: "10.29.141.193"
       silvus: "192.168.100.3"
-  sequia:
+  sequoia:
     role: base_station
     desc: "Base station"
     addresses:

--- a/dcist_launch_system/src/dcist_launch_system/fleet_helpers.py
+++ b/dcist_launch_system/src/dcist_launch_system/fleet_helpers.py
@@ -447,11 +447,17 @@ def hash_remote_experiment(user, ip, output_root, experiment):
     return hashes
 
 
-def get_remote_status(user, ip, silvus_ips=None, platform_type=None):
+def get_remote_status(
+    user, ip, silvus_ips=None, platform_type=None,
+    doodlelabs_ips=None, doodlelabs_creds=None,
+):
     """Get system status from a remote machine.
 
     Returns dict with keys: tmux_sessions, ros2_procs, load, disk, radio.
     platform_type: if "spot", queries Spot robot battery via ROS 2 topic instead of sysfs.
+    silvus_ips: list of Silvus mgmt IPs to probe. If set, uses Silvus API.
+    doodlelabs_ips: list of Doodle Labs IPs. If set (and silvus_ips is not),
+        uses Doodle Labs HTTPS/ubus API instead.
     """
     # Spot robots don't expose battery via /sys/class/power_supply; query the ROS 2 topic.
     if platform_type == "spot":
@@ -531,7 +537,73 @@ else:
 """
         encoded = base64.b64encode(py_script.encode()).decode()
         args = " ".join(shlex.quote(ip) for ip in silvus_ips)
-        cmd += f"; echo '---SILVUS---'; echo '{encoded}' | base64 -d | python3 - {args}"
+        cmd += f"; echo '---RADIO---'; echo '{encoded}' | base64 -d | python3 - {args}"
+    elif doodlelabs_ips:
+        # Doodle Labs: HTTPS/ubus with session login. Formats as "Bat: X.XXV, Mesh: N"
+        py_script = """
+import urllib.request, json, ssl, sys
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+if len(sys.argv) < 3:
+    print('N/A'); sys.exit(0)
+user, password = sys.argv[1], sys.argv[2]
+ips = sys.argv[3:] or ['192.168.153.1']
+null_token = '00000000000000000000000000000000'
+def rpc(base, token, obj, method, args=None):
+    payload = json.dumps({'jsonrpc':'2.0','id':1,'method':'call',
+                          'params':[token, obj, method, args or {}]}).encode()
+    req = urllib.request.Request(base, data=payload,
+                                 headers={'Content-Type':'application/json'})
+    with urllib.request.urlopen(req, timeout=2, context=ctx) as resp:
+        d = json.loads(resp.read())
+    r = d.get('result', [])
+    return (r[0], r[1]) if len(r) >= 2 else (-1, None)
+local_ip, token = None, None
+for ip in ips:
+    try:
+        code, ld = rpc(f'https://{ip}/ubus', null_token, 'session', 'login',
+                       {'username': user, 'password': password})
+        if code == 0 and ld:
+            local_ip, token = ip, ld['ubus_rpc_session']; break
+    except Exception:
+        pass
+if not local_ip:
+    print('N/A'); sys.exit(0)
+try:
+    base = f'https://{local_ip}/ubus'
+    # Battery voltage from pancake.txt (wearable only)
+    bat_str = '?'
+    code, data = rpc(base, token, 'file', 'exec',
+                     {'command':'cat','params':['/tmp/run/pancake.txt']})
+    if code == 0 and data and data.get('stdout'):
+        try:
+            p = json.loads(data['stdout'])
+            vin = p.get('VIN VOLTAGE', p.get('vin_voltage'))
+            if vin is not None:
+                bat_str = f'{float(vin)/20.2:.1f}V'
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+    # Mesh node count from linkstate
+    mesh = 0
+    code, data = rpc(base, token, 'file', 'read',
+                     {'path':'/tmp/linkstate_current.json','base64':False})
+    if code == 0 and data and data.get('data'):
+        try:
+            ls = json.loads(data['data'])
+            mesh = len(ls.get('mesh_stats', []))
+        except json.JSONDecodeError:
+            pass
+    print(f'Bat: {bat_str}, Mesh: {mesh}')
+except Exception:
+    print('API Error')
+"""
+        encoded = base64.b64encode(py_script.encode()).decode()
+        ruser, rpw = doodlelabs_creds or ("user", "DoodleSmartRadio")
+        args = " ".join(
+            shlex.quote(a) for a in [ruser, rpw, *doodlelabs_ips]
+        )
+        cmd += f"; echo '---RADIO---'; echo '{encoded}' | base64 -d | python3 - {args}"
 
     rc, stdout, _ = ssh_cmd(user, ip, cmd, timeout=10)
     if rc != 0 or not stdout:
@@ -594,7 +666,11 @@ else:
         "gpu": raw_gpu,
         "disk": (sections.get("DISK", ["N/A"])[0] or "N/A"),
         "battery": raw_bat,
-        "radio": (sections.get("SILVUS", ["N/A"])[0] or "N/A"),
+        "radio": (
+            sections.get("RADIO", [None])[0]
+            or sections.get("SILVUS", ["N/A"])[0]
+            or "N/A"
+        ),
     }
 
 
@@ -1334,7 +1410,7 @@ except Exception as e:
     import base64
 
     encoded = base64.b64encode(py_script.encode()).decode()
-    args = " ".join(silvus_mgmt_ips)
+    args = " ".join(shlex.quote(ip) for ip in silvus_mgmt_ips)
     cmd = f"echo '{encoded}' | base64 -d | python3 - {args}"
     rc, stdout, _ = ssh_cmd(user, ip, cmd, timeout=8)
     if rc != 0 or not stdout or stdout.strip() in ("N/A", ""):
@@ -1429,6 +1505,375 @@ def get_silvus_radio_details(topology):
             }
 
     return results
+
+
+# ---- Doodle Labs Mesh Rider radios (HTTPS JSON-RPC ubus API) ----
+#
+# Key differences from Silvus:
+#   - HTTPS (self-signed cert), not HTTP
+#   - OpenWrt ubus JSON-RPC at /ubus, not /cgi-bin/streamscape_api
+#   - Requires session login to get an auth token
+#   - Default creds: user / DoodleSmartRadio
+#   - Per-peer stats from /tmp/linkstate_current.json (file read)
+#   - Wearable battery/temp from /tmp/run/pancake.txt (VIN / 20.2 = volts)
+#   - Mesh uses batman-adv (TQ quality 0-255), not per-link RSSI
+#
+# Auto-detection: if topology has doodlelabs_radios, that wins. Otherwise
+# falls back to silvus_radios. Machines still live on the silvus data network
+# (192.168.100.x) for SSH/zenoh — only the radio monitoring protocol differs.
+
+
+def get_active_radio_type(topology, override=None):
+    """Return 'doodlelabs', 'silvus', or None.
+
+    If override is 'silvus', 'doodlelabs', or 'none', that wins. If override
+    is 'auto' or None, auto-detects from topology: Doodle Labs wins if both
+    sections are populated.
+
+    The CLI exposes this via `--radio-type` on the fleet-adt4 command.
+    """
+    if override and override != "auto":
+        if override == "none":
+            return None
+        if override in ("silvus", "doodlelabs"):
+            return override
+        # Unknown override — fall through to auto-detect
+    if topology.get("doodlelabs_radios", {}).get("radios"):
+        return "doodlelabs"
+    if topology.get("silvus_radios", {}).get("radios"):
+        return "silvus"
+    return None
+
+
+_DOODLELABS_QUERY_SCRIPT = """
+import urllib.request, json, ssl, sys
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+if len(sys.argv) < 3:
+    print('N/A'); sys.exit(0)
+user, password = sys.argv[1], sys.argv[2]
+ips = sys.argv[3:] or ['192.168.153.1']
+
+null_token = '00000000000000000000000000000000'
+
+def rpc(base, token, obj, method, args=None):
+    payload = json.dumps({'jsonrpc':'2.0','id':1,'method':'call',
+                          'params':[token, obj, method, args or {}]}).encode()
+    req = urllib.request.Request(base, data=payload,
+                                 headers={'Content-Type':'application/json'})
+    with urllib.request.urlopen(req, timeout=3, context=ctx) as resp:
+        d = json.loads(resp.read())
+    r = d.get('result', [])
+    return (r[0], r[1]) if len(r) >= 2 else (-1, None)
+
+local_ip, token = None, None
+for ip in ips:
+    try:
+        code, ld = rpc(f'https://{ip}/ubus', null_token, 'session', 'login',
+                       {'username': user, 'password': password})
+        if code == 0 and ld:
+            local_ip, token = ip, ld['ubus_rpc_session']; break
+    except Exception:
+        continue
+
+if not local_ip:
+    print('N/A'); sys.exit(0)
+
+try:
+    base = f'https://{local_ip}/ubus'
+    code, board = rpc(base, token, 'system', 'board', {})
+    hostname = (board or {}).get('hostname', '') if code == 0 else ''
+    code, iw = rpc(base, token, 'iwinfo', 'info', {'device':'wlan0'})
+    iw = iw or {}
+    signal = iw.get('signal'); noise = iw.get('noise')
+    bssid = iw.get('bssid', ''); bitrate = iw.get('bitrate')
+    mesh_nodes = neighbor_count = 0
+    code, data = rpc(base, token, 'file', 'read',
+                     {'path':'/tmp/linkstate_current.json','base64':False})
+    if code == 0 and data and data.get('data'):
+        try:
+            ls = json.loads(data['data'])
+            mesh_nodes = len(ls.get('mesh_stats', []))
+            neighbor_count = len(ls.get('sta_stats', []))
+        except json.JSONDecodeError:
+            pass
+    bat_v = temp = None
+    code, data = rpc(base, token, 'file', 'exec',
+                     {'command':'cat','params':['/tmp/run/pancake.txt']})
+    if code == 0 and data and data.get('stdout'):
+        try:
+            p = json.loads(data['stdout'])
+            vin = p.get('VIN VOLTAGE', p.get('vin_voltage'))
+            if vin is not None: bat_v = float(vin) / 20.2
+            t = p.get('Temperature', p.get('temperature'))
+            if t is not None: temp = float(t)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+    bat_s = f'{bat_v:.2f}' if bat_v is not None else '?'
+    sig_s = str(signal) if signal is not None else '?'
+    noise_s = str(noise) if noise is not None else '?'
+    br_s = str(bitrate) if bitrate is not None else '?'
+    temp_s = f'{temp:.0f}' if temp is not None else '?'
+    print(f'{bat_s}|{mesh_nodes}|{neighbor_count}|{sig_s}|{noise_s}|{br_s}|{bssid}|{hostname}|{temp_s}')
+except Exception as e:
+    print(f'ERR:{e}')
+"""
+
+
+def _doodlelabs_creds(topology):
+    """Return (user, password) using the first radio's creds from topology."""
+    radios = topology.get("doodlelabs_radios", {}).get("radios", {})
+    for r in radios.values():
+        return (r.get("user", "user"), r.get("password", "DoodleSmartRadio"))
+    return ("user", "DoodleSmartRadio")
+
+
+def get_doodlelabs_link_quality(user, ip, dl_ips=None, dl_creds=None):
+    """Query a machine's local Doodle Labs radio for link quality via SSH.
+
+    The remote machine runs a Python script that connects to its directly-
+    attached radio (default 192.168.153.1) via HTTPS/ubus. Returns dict with
+    battery_v, mesh_nodes, neighbor_count, signal, noise, bitrate, bssid,
+    hostname, temperature; or None on failure, {'error': ...} on auth error.
+    """
+    if not dl_ips:
+        dl_ips = ["192.168.153.1"]
+    radio_user, radio_pw = dl_creds or ("user", "DoodleSmartRadio")
+
+    encoded = base64.b64encode(_DOODLELABS_QUERY_SCRIPT.encode()).decode()
+    args = " ".join(shlex.quote(a) for a in [radio_user, radio_pw, *dl_ips])
+    cmd = f"echo '{encoded}' | base64 -d | python3 - {args}"
+
+    rc, stdout, _ = ssh_cmd(user, ip, cmd, timeout=10)
+    if rc != 0 or not stdout:
+        return None
+    line = stdout.strip()
+    if line in ("", "N/A"):
+        return None
+    if line.startswith("ERR:"):
+        return {"error": line}
+
+    parts = line.split("|")
+    if len(parts) < 6:
+        return {"raw": line}
+
+    def _v(s, cast=str):
+        if s in ("", "?", "N/A"):
+            return None
+        try:
+            return cast(s)
+        except (ValueError, TypeError):
+            return None
+
+    def _int(s):
+        # iwinfo returns these as JSON numbers; may arrive as int or float str.
+        return int(float(s))
+
+    return {
+        "battery_v": _v(parts[0], float),
+        "mesh_nodes": _v(parts[1], _int),
+        "neighbor_count": _v(parts[2], _int),
+        "signal": _v(parts[3], _int),
+        "noise": _v(parts[4], _int),
+        "bitrate": _v(parts[5], _int),
+        "bssid": parts[6] if len(parts) > 6 and parts[6] else None,
+        "hostname": parts[7] if len(parts) > 7 and parts[7] else None,
+        "temperature": _v(parts[8], float) if len(parts) > 8 else None,
+    }
+
+
+def get_doodlelabs_radio_details(topology):
+    """Query all Doodle Labs radios directly via HTTPS from the local machine.
+
+    Returns dict[radio_name -> info] with ip, hostname, firmware, bssid,
+    signal, noise, bitrate, battery_v, temperature, htmode, frequency,
+    channel, txpower, sta_stats, mesh_stats, error.
+    """
+    import ssl as _ssl
+    import urllib.request as _urlreq
+
+    radios = topology.get("doodlelabs_radios", {}).get("radios", {})
+    if not radios:
+        return {}
+
+    ctx = _ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = _ssl.CERT_NONE
+    null_token = "00000000000000000000000000000000"
+
+    def _rpc(base, token, obj, method, args=None):
+        payload = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "call",
+             "params": [token, obj, method, args or {}]}
+        ).encode()
+        req = _urlreq.Request(
+            base, data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        with _urlreq.urlopen(req, timeout=4, context=ctx) as resp:
+            d = json.loads(resp.read())
+        r = d.get("result", [])
+        return (r[0], r[1]) if len(r) >= 2 else (-1, None)
+
+    results = {}
+    for name, rcfg in radios.items():
+        ip = rcfg.get("ip")
+        if not ip:
+            continue
+        ruser = rcfg.get("user", "user")
+        rpw = rcfg.get("password", "DoodleSmartRadio")
+        base = f"https://{ip}/ubus"
+
+        info = {"ip": ip, "error": None}
+        try:
+            code, login = _rpc(
+                base, null_token, "session", "login",
+                {"username": ruser, "password": rpw},
+            )
+            if code != 0 or not login:
+                info["error"] = "auth failed"
+                results[name] = info
+                continue
+            token = login["ubus_rpc_session"]
+
+            code, board = _rpc(base, token, "system", "board", {})
+            if code == 0 and board:
+                info["hostname"] = board.get("hostname")
+                info["model"] = board.get("model")
+                rel = board.get("release", {}) or {}
+                info["firmware"] = rel.get("description", rel.get("version"))
+
+            code, iw = _rpc(base, token, "iwinfo", "info", {"device": "wlan0"})
+            if code == 0 and iw:
+                info["bssid"] = (iw.get("bssid") or "").lower() or None
+                info["signal"] = iw.get("signal")
+                info["noise"] = iw.get("noise")
+                info["bitrate"] = iw.get("bitrate")
+                info["htmode"] = iw.get("htmode")
+                info["frequency"] = iw.get("frequency")
+                info["channel"] = iw.get("channel")
+                info["txpower"] = iw.get("txpower")
+
+            code, data = _rpc(
+                base, token, "file", "read",
+                {"path": "/tmp/linkstate_current.json", "base64": False},
+            )
+            sta_stats = []
+            mesh_stats = []
+            if code == 0 and data and data.get("data"):
+                try:
+                    ls = json.loads(data["data"])
+                    sta_stats = ls.get("sta_stats", []) or []
+                    mesh_stats = ls.get("mesh_stats", []) or []
+                except json.JSONDecodeError:
+                    pass
+            info["sta_stats"] = sta_stats
+            info["mesh_stats"] = mesh_stats
+
+            code, data = _rpc(
+                base, token, "file", "exec",
+                {"command": "cat", "params": ["/tmp/run/pancake.txt"]},
+            )
+            if code == 0 and data and data.get("stdout"):
+                try:
+                    p = json.loads(data["stdout"])
+                    vin = p.get("VIN VOLTAGE", p.get("vin_voltage"))
+                    if vin is not None:
+                        info["battery_v"] = float(vin) / 20.2
+                    t = p.get("Temperature", p.get("temperature"))
+                    if t is not None:
+                        info["temperature"] = float(t)
+                except (json.JSONDecodeError, ValueError, TypeError):
+                    pass
+        except Exception as e:
+            info["error"] = str(e)
+
+        results[name] = info
+
+    return results
+
+
+def check_doodlelabs_route(
+    user=None, ip=None, mgmt_subnet="10.223.0.0/16",
+    local_subnet_pat="192.168.153.",
+):
+    """Check if a route to the Doodle Labs mesh subnet exists.
+
+    Each machine with a USB-attached Doodle Labs radio has a 192.168.153.x
+    address; the 10.223.0.0/16 mesh subnet must be routed via that interface
+    to reach non-directly-connected radios. If user/ip are None, checks
+    locally. Returns dict with has_route, interface (None if no 192.168.153.x
+    addr), route_info.
+    """
+    cmd = (
+        f"iface=$(ip -4 -o addr show | grep {shlex.quote(local_subnet_pat)} "
+        "| awk '{print $2}' | head -1); "
+        f"route=$(ip route show {shlex.quote(mgmt_subnet)} 2>/dev/null | head -1); "
+        'echo "$iface|$route"'
+    )
+    if user and ip:
+        rc, out, _ = ssh_cmd(user, ip, cmd, timeout=5)
+    else:
+        try:
+            result = subprocess.run(
+                ["bash", "-c", cmd], capture_output=True, text=True, timeout=5
+            )
+            out = result.stdout.strip()
+            rc = result.returncode
+        except Exception:
+            return {"has_route": False, "interface": None, "dl_iface": None}
+
+    if rc != 0 or not out:
+        return {"has_route": False, "interface": None, "dl_iface": None}
+
+    parts = out.strip().split("|", 1)
+    iface = parts[0].strip() if parts[0].strip() else None
+    route_line = parts[1].strip() if len(parts) > 1 else ""
+    return {
+        "has_route": bool(route_line),
+        "interface": iface,
+        "dl_iface": iface,
+        "route_info": route_line if route_line else None,
+    }
+
+
+def add_doodlelabs_route(
+    user=None, ip=None, mgmt_subnet="10.223.0.0/16", interface=None
+):
+    """Add a route to the Doodle Labs mesh subnet via the USB-ethernet
+    interface. If user/ip are None, runs locally. Requires sudo.
+    Returns (success: bool, message: str)."""
+    if not interface:
+        info = check_doodlelabs_route(user, ip, mgmt_subnet)
+        interface = info.get("dl_iface")
+        if not interface:
+            return False, (
+                "No Doodle Labs interface found (no 192.168.153.x address). "
+                "Is the radio plugged in via USB-ethernet?"
+            )
+        if info["has_route"]:
+            return True, f"Route already exists: {info['route_info']}"
+
+    cmd = f"sudo ip route add {mgmt_subnet} dev {shlex.quote(interface)}"
+    if user and ip:
+        rc, _, err = ssh_cmd(user, ip, cmd, timeout=10)
+    else:
+        try:
+            result = subprocess.run(
+                ["bash", "-c", cmd], capture_output=True, text=True, timeout=10
+            )
+            rc, err = result.returncode, result.stderr.strip()
+        except Exception as e:
+            return False, str(e)
+
+    if rc == 0:
+        return True, f"Route added: {mgmt_subnet} dev {interface}"
+    if "File exists" in err:
+        return True, f"Route already exists on {interface}"
+    return False, f"Failed (rc={rc}): {err}"
 
 
 # ---- Bandwidth testing (iperf3) ----

--- a/dcist_launch_system/src/dcist_launch_system/fleet_helpers.py
+++ b/dcist_launch_system/src/dcist_launch_system/fleet_helpers.py
@@ -448,8 +448,12 @@ def hash_remote_experiment(user, ip, output_root, experiment):
 
 
 def get_remote_status(
-    user, ip, silvus_ips=None, platform_type=None,
-    doodlelabs_ips=None, doodlelabs_creds=None,
+    user,
+    ip,
+    silvus_ips=None,
+    platform_type=None,
+    doodlelabs_ips=None,
+    doodlelabs_creds=None,
 ):
     """Get system status from a remote machine.
 
@@ -600,9 +604,7 @@ except Exception:
 """
         encoded = base64.b64encode(py_script.encode()).decode()
         ruser, rpw = doodlelabs_creds or ("user", "DoodleSmartRadio")
-        args = " ".join(
-            shlex.quote(a) for a in [ruser, rpw, *doodlelabs_ips]
-        )
+        args = " ".join(shlex.quote(a) for a in [ruser, rpw, *doodlelabs_ips])
         cmd += f"; echo '---RADIO---'; echo '{encoded}' | base64 -d | python3 - {args}"
 
     rc, stdout, _ = ssh_cmd(user, ip, cmd, timeout=10)
@@ -1706,11 +1708,16 @@ def get_doodlelabs_radio_details(topology):
 
     def _rpc(base, token, obj, method, args=None):
         payload = json.dumps(
-            {"jsonrpc": "2.0", "id": 1, "method": "call",
-             "params": [token, obj, method, args or {}]}
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "call",
+                "params": [token, obj, method, args or {}],
+            }
         ).encode()
         req = _urlreq.Request(
-            base, data=payload,
+            base,
+            data=payload,
             headers={"Content-Type": "application/json"},
         )
         with _urlreq.urlopen(req, timeout=4, context=ctx) as resp:
@@ -1730,7 +1737,10 @@ def get_doodlelabs_radio_details(topology):
         info = {"ip": ip, "error": None}
         try:
             code, login = _rpc(
-                base, null_token, "session", "login",
+                base,
+                null_token,
+                "session",
+                "login",
                 {"username": ruser, "password": rpw},
             )
             if code != 0 or not login:
@@ -1758,7 +1768,10 @@ def get_doodlelabs_radio_details(topology):
                 info["txpower"] = iw.get("txpower")
 
             code, data = _rpc(
-                base, token, "file", "read",
+                base,
+                token,
+                "file",
+                "read",
                 {"path": "/tmp/linkstate_current.json", "base64": False},
             )
             sta_stats = []
@@ -1774,7 +1787,10 @@ def get_doodlelabs_radio_details(topology):
             info["mesh_stats"] = mesh_stats
 
             code, data = _rpc(
-                base, token, "file", "exec",
+                base,
+                token,
+                "file",
+                "exec",
                 {"command": "cat", "params": ["/tmp/run/pancake.txt"]},
             )
             if code == 0 and data and data.get("stdout"):
@@ -1797,7 +1813,9 @@ def get_doodlelabs_radio_details(topology):
 
 
 def check_doodlelabs_route(
-    user=None, ip=None, mgmt_subnet="10.223.0.0/16",
+    user=None,
+    ip=None,
+    mgmt_subnet="10.223.0.0/16",
     local_subnet_pat="192.168.153.",
 ):
     """Check if a route to the Doodle Labs mesh subnet exists.

--- a/dcist_launch_system/src/dcist_launch_system/tui/__init__.py
+++ b/dcist_launch_system/src/dcist_launch_system/tui/__init__.py
@@ -102,15 +102,26 @@ class FleetContext:
 )
 @click.option("--topology", "-t", type=click.Path(exists=True), default=None)
 @click.option("--output-root", "-o", default="~/adt4_output", help="Remote output root")
+@click.option(
+    "--radio-type",
+    type=click.Choice(["auto", "silvus", "doodlelabs", "none"]),
+    default="auto",
+    help=(
+        "Radio type to monitor. 'auto' (default) infers from topology.yaml: "
+        "doodlelabs wins if both sections are populated. 'none' disables "
+        "radio monitoring entirely."
+    ),
+)
 @click.pass_context
-def cli(ctx, network, topology, output_root):
+def cli(ctx, network, topology, output_root, radio_type):
     """ADT4 Fleet Management Tool. Run without subcommand for interactive TUI."""
     ctx.ensure_object(dict)
     ctx.obj["network"] = network
     ctx.obj["topology"] = topology
     ctx.obj["output_root"] = output_root
+    ctx.obj["radio_type"] = radio_type
     if ctx.invoked_subcommand is None:
-        _launch_tui(network, topology, output_root)
+        _launch_tui(network, topology, output_root, radio_type)
 
 
 # --- status ---

--- a/dcist_launch_system/src/dcist_launch_system/tui/app.py
+++ b/dcist_launch_system/src/dcist_launch_system/tui/app.py
@@ -276,7 +276,10 @@ class FleetApp(App):
 
 
 def _launch_tui(
-    network: str | None, topology_path: str | None, output_root: str
+    network: str | None,
+    topology_path: str | None,
+    output_root: str,
+    radio_type: str = "auto",
 ) -> None:
     """Build TuiContext and run FleetApp."""
     try:
@@ -304,6 +307,7 @@ def _launch_tui(
         active_network=active_network,
         topology_path=topology_path,
         output_root=output_root,
+        radio_type_override=radio_type,
         runtime_config=runtime_config,
         _local_ips=local_ips,
     )

--- a/dcist_launch_system/src/dcist_launch_system/tui/context.py
+++ b/dcist_launch_system/src/dcist_launch_system/tui/context.py
@@ -17,6 +17,9 @@ class TuiContext:
     active_network: str
     topology_path: str | None
     output_root: str
+    # User-selected radio type: 'silvus', 'doodlelabs', 'none', 'auto', or None.
+    # 'auto' / None means infer from topology (doodlelabs wins if both present).
+    radio_type_override: str | None = None
     runtime_config: dict[str, dict] = field(default_factory=dict)
     _deleted_machines: set[str] = field(default_factory=set)
     _local_ips: set[str] = field(default_factory=set)

--- a/dcist_launch_system/src/dcist_launch_system/tui/screens/monitor.py
+++ b/dcist_launch_system/src/dcist_launch_system/tui/screens/monitor.py
@@ -25,10 +25,14 @@ from dcist_launch_system.fleet_helpers import (
     _STATUS_NAMES,
     _STATUS_NOMINAL,
     NodeStatusPoller,
+    check_doodlelabs_route,
     check_silvus_route,
     check_zenoh_port,
     compute_robot_readiness,
     generate_namespaced_rviz,
+    get_active_radio_type,
+    get_doodlelabs_link_quality,
+    get_doodlelabs_radio_details,
     get_local_ip_for_network,
     get_remote_status,
     get_silvus_link_quality,
@@ -139,8 +143,27 @@ class MonitorScreen(ModalScreen):
             machines = [
                 m for m in self.ctx.runtime_config.values() if m.get("online", False)
             ]
-            sys_radios = self.ctx.topo.get("silvus_radios", {}).get("radios", {})
-            silvus_ips = [r["mgmt_ip"] for r in sys_radios.values() if "mgmt_ip" in r]
+            radio_type = get_active_radio_type(self.ctx.topo, self.ctx.radio_type_override)
+            silvus_ips = None
+            dl_ips = None
+            dl_creds = None
+            if radio_type == "silvus":
+                sys_radios = self.ctx.topo.get("silvus_radios", {}).get("radios", {})
+                silvus_ips = [
+                    r["mgmt_ip"] for r in sys_radios.values() if "mgmt_ip" in r
+                ]
+            elif radio_type == "doodlelabs":
+                dl_radios = self.ctx.topo.get("doodlelabs_radios", {}).get(
+                    "radios", {}
+                )
+                dl_ips = [r["ip"] for r in dl_radios.values() if "ip" in r]
+                # Use first radio's creds (assume uniform across fleet)
+                for r in dl_radios.values():
+                    dl_creds = (
+                        r.get("user", "user"),
+                        r.get("password", "DoodleSmartRadio"),
+                    )
+                    break
 
             def fetch(m):
                 return get_remote_status(
@@ -148,6 +171,8 @@ class MonitorScreen(ModalScreen):
                     m["ip"],
                     silvus_ips=silvus_ips,
                     platform_type=m.get("platform_type"),
+                    doodlelabs_ips=dl_ips,
+                    doodlelabs_creds=dl_creds,
                 )
 
             return run_parallel(fetch, machines)
@@ -358,10 +383,26 @@ class MonitorScreen(ModalScreen):
 
         def do_check():
             machines = list(self.ctx.runtime_config.values())
-            sys_radios = self.ctx.topo.get("silvus_radios", {}).get("radios", {})
-            silvus_mgmt_ips = [
-                r["mgmt_ip"] for r in sys_radios.values() if "mgmt_ip" in r
-            ]
+            radio_type = get_active_radio_type(self.ctx.topo, self.ctx.radio_type_override)
+            silvus_mgmt_ips = []
+            dl_ips = []
+            dl_creds = None
+            if radio_type == "silvus":
+                sys_radios = self.ctx.topo.get("silvus_radios", {}).get("radios", {})
+                silvus_mgmt_ips = [
+                    r["mgmt_ip"] for r in sys_radios.values() if "mgmt_ip" in r
+                ]
+            elif radio_type == "doodlelabs":
+                dl_radios = self.ctx.topo.get("doodlelabs_radios", {}).get(
+                    "radios", {}
+                )
+                dl_ips = [r["ip"] for r in dl_radios.values() if "ip" in r]
+                for r in dl_radios.values():
+                    dl_creds = (
+                        r.get("user", "user"),
+                        r.get("password", "DoodleSmartRadio"),
+                    )
+                    break
 
             results = []
             for m in machines:
@@ -369,9 +410,16 @@ class MonitorScreen(ModalScreen):
                 zenoh_ok = check_zenoh_port(ip, port=zenoh_port)
 
                 radio = None
-                if m.get("online") and silvus_mgmt_ips:
+                if m.get("online"):
                     try:
-                        radio = get_silvus_link_quality(m["user"], ip, silvus_mgmt_ips)
+                        if radio_type == "silvus" and silvus_mgmt_ips:
+                            radio = get_silvus_link_quality(
+                                m["user"], ip, silvus_mgmt_ips
+                            )
+                        elif radio_type == "doodlelabs" and dl_ips:
+                            radio = get_doodlelabs_link_quality(
+                                m["user"], ip, dl_ips, dl_creds
+                            )
                     except Exception:
                         pass
 
@@ -401,9 +449,15 @@ class MonitorScreen(ModalScreen):
                 )
 
             has_radio = any(r for _, _, r in results if r)
+            radio_type = get_active_radio_type(self.ctx.topo, self.ctx.radio_type_override)
             if has_radio:
-                log.write("\n[bold]Silvus Radio Link Quality:[/]")
-                radio_assignment = []  # (machine_name, node_id)
+                label = (
+                    "Doodle Labs"
+                    if radio_type == "doodlelabs"
+                    else "Silvus"
+                )
+                log.write(f"\n[bold]{label} Radio Link Quality:[/]")
+                radio_assignment = []  # (machine_name, node_id_or_bssid)
                 for m, _, radio in sorted(results, key=lambda x: x[0]["name"]):
                     if not radio:
                         continue
@@ -411,6 +465,29 @@ class MonitorScreen(ModalScreen):
                         log.write(f"  [red]{m['name']:12s} {radio['error']}[/]")
                     elif "raw" in radio:
                         log.write(f"  [dim]{m['name']:12s} {radio['raw']}[/]")
+                    elif radio_type == "doodlelabs":
+                        bat_v = radio.get("battery_v")
+                        bat_s = f"{bat_v:.2f}V" if bat_v is not None else "?"
+                        mesh = radio.get("mesh_nodes", "?")
+                        neighbors = radio.get("neighbor_count", "?")
+                        sig = radio.get("signal")
+                        noise = radio.get("noise")
+                        sig_s = f"{sig}dBm" if sig is not None else "N/A"
+                        snr_s = (
+                            f"{sig - noise}dB"
+                            if sig is not None and noise is not None
+                            else "N/A"
+                        )
+                        temp = radio.get("temperature")
+                        temp_s = f" Temp:{temp:.0f}C" if temp is not None else ""
+                        log.write(
+                            f"  [cyan]{m['name']:12s}[/] "
+                            f"Bat:{bat_s} Mesh:{mesh} Peers:{neighbors} "
+                            f"Signal:{sig_s} SNR:{snr_s}{temp_s}"
+                        )
+                        bssid = radio.get("bssid")
+                        if bssid:
+                            radio_assignment.append((m["name"], bssid))
                     else:
                         bat = radio.get("battery", "?")
                         mesh = radio.get("mesh_nodes", "?")
@@ -427,9 +504,10 @@ class MonitorScreen(ModalScreen):
                             radio_assignment.append((m["name"], nid))
 
                 if radio_assignment:
-                    log.write("\n[bold]Radio Assignment (current):[/]")
-                    for mname, nid in radio_assignment:
-                        log.write(f"  [cyan]{mname:12s}[/] → node {nid}")
+                    id_label = "BSSID" if radio_type == "doodlelabs" else "node"
+                    log.write(f"\n[bold]Radio Assignment (current):[/]")
+                    for mname, rid in radio_assignment:
+                        log.write(f"  [cyan]{mname:12s}[/] → {id_label} {rid}")
                     log.write(
                         "  [dim]Press F4 to see RSSI matrix and mesh topology.[/]"
                     )
@@ -468,25 +546,37 @@ class MonitorScreen(ModalScreen):
         threading.Thread(target=bg, daemon=True).start()
 
     def action_check_silvus_routes(self):
-        """Check if Silvus management route exists on all machines + locally."""
-        log = self.query_one("#monitor_log", RichLog)
-        log.write("[dim]Checking Silvus management routes...[/]")
+        """Check if the radio management route exists on all machines + locally.
 
-        mgmt_subnet = self.ctx.topo.get("silvus_radios", {}).get(
-            "mgmt_subnet", "172.20.0.0/16"
-        )
+        Dispatches to the Silvus 172.20.0.0/16 check or the Doodle Labs
+        10.223.0.0/16 check based on radio type in topology.yaml.
+        """
+        log = self.query_one("#monitor_log", RichLog)
+        radio_type = get_active_radio_type(self.ctx.topo, self.ctx.radio_type_override)
+        if radio_type == "doodlelabs":
+            dl_cfg = self.ctx.topo.get("doodlelabs_radios", {})
+            mgmt_subnet = dl_cfg.get("mgmt_subnet", "10.223.0.0/16")
+            check_fn = check_doodlelabs_route
+            label = "Doodle Labs Mesh"
+        else:
+            mgmt_subnet = self.ctx.topo.get("silvus_radios", {}).get(
+                "mgmt_subnet", "172.20.0.0/16"
+            )
+            check_fn = check_silvus_route
+            label = "Silvus Management"
+        log.write(f"[dim]Checking {label} routes ({mgmt_subnet})...[/]")
 
         def do_check():
             results = []
             # Check local machine first
-            local_info = check_silvus_route(mgmt_subnet=mgmt_subnet)
+            local_info = check_fn(mgmt_subnet=mgmt_subnet)
             results.append(("LOCAL", None, local_info))
 
             # Check all online machines
             machines = [m for m in self.ctx.runtime_config.values() if m.get("online")]
             for m in machines:
                 try:
-                    info = check_silvus_route(m["user"], m["ip"], mgmt_subnet)
+                    info = check_fn(m["user"], m["ip"], mgmt_subnet)
                     results.append((m["name"], m, info))
                 except Exception as e:
                     results.append(
@@ -497,29 +587,43 @@ class MonitorScreen(ModalScreen):
                                 "has_route": False,
                                 "interface": None,
                                 "silvus_iface": None,
+                                "dl_iface": None,
                                 "error": str(e),
                             },
                         )
                     )
             return results
 
+        data_subnet = (
+            "192.168.153.x" if radio_type == "doodlelabs" else "192.168.100.x"
+        )
+
         def on_done(results):
-            log.write(f"\n[bold]Silvus Management Route ({mgmt_subnet}):[/]")
+            log.write(f"\n[bold]{label} Route ({mgmt_subnet}):[/]")
             missing = []
+            local_no_iface = False
             for name, m, info in sorted(results, key=lambda x: x[0]):
-                iface = info.get("silvus_iface") or "—"
+                iface = (
+                    info.get("interface")
+                    or info.get("dl_iface")
+                    or info.get("silvus_iface")
+                    or "—"
+                )
+                has_iface = iface != "—"
                 if info.get("has_route"):
                     route = info.get("route_info", "OK")
                     log.write(
                         f"  [green]{name:12s}[/] iface={iface}  [green]ROUTE OK[/] ({route})"
                     )
-                elif info.get("silvus_iface"):
+                elif has_iface:
                     log.write(f"  [red]{name:12s}[/] iface={iface}  [red]NO ROUTE[/]")
                     missing.append((name, m, iface))
                 else:
                     log.write(
-                        f"  [dim]{name:12s}[/] [dim]No Silvus interface (no 192.168.100.x address)[/]"
+                        f"  [dim]{name:12s}[/] [dim]No {label.split()[0]} interface (no {data_subnet} address)[/]"
                     )
+                    if name == "LOCAL":
+                        local_no_iface = True
             if missing:
                 log.write("\n[bold yellow]Run these commands to add missing routes:[/]")
                 for name, m, iface in missing:
@@ -552,6 +656,45 @@ class MonitorScreen(ModalScreen):
                             f'    [cyan]  nmcli con modify "$conn" +ipv4.routes "{mgmt_subnet}"[/]'
                         )
                         log.write('    [cyan]  nmcli con up "$conn"[/]')
+            if local_no_iface:
+                # Show a template command for local even when the interface
+                # isn't present yet (USB unplugged, or not auto-configured).
+                log.write(
+                    "\n[bold yellow]Local has no "
+                    f"{data_subnet} interface.[/]"
+                )
+                if radio_type == "doodlelabs":
+                    log.write(
+                        "  [dim]Plug in the Doodle Labs radio via USB-ethernet, "
+                        "then find the interface name:[/]"
+                    )
+                else:
+                    log.write(
+                        "  [dim]Connect to the Silvus network, then find the "
+                        "interface name:[/]"
+                    )
+                log.write(
+                    f"    [cyan]ip -o addr show | grep '{data_subnet[:-1]}'[/]"
+                )
+                log.write(
+                    "  [dim]Then add the route (replace <iface> with what you "
+                    "found above):[/]"
+                )
+                log.write(
+                    f"    [cyan]sudo ip route add {mgmt_subnet} dev <iface>[/]"
+                )
+                log.write(
+                    "  [dim]For permanent route via NetworkManager:[/]"
+                )
+                log.write(
+                    f"    [cyan]conn=$(nmcli -f NAME,DEVICE con show "
+                    "| grep <iface> | awk '{print $1}')[/]"
+                )
+                log.write(
+                    f'    [cyan]nmcli con modify "$conn" +ipv4.routes '
+                    f'"{mgmt_subnet}"[/]'
+                )
+                log.write('    [cyan]nmcli con up "$conn"[/]')
 
         def bg():
             results = do_check()
@@ -560,8 +703,19 @@ class MonitorScreen(ModalScreen):
         threading.Thread(target=bg, daemon=True).start()
 
     def action_silvus_detail(self):
-        """Show Silvus RSSI link quality matrix and mesh routing topology."""
+        """Show radio RSSI link quality matrix and mesh routing topology.
+
+        Dispatches to Silvus or Doodle Labs based on which radio type is
+        configured in topology.yaml.
+        """
         log = self.query_one("#monitor_log", RichLog)
+        radio_type = get_active_radio_type(self.ctx.topo, self.ctx.radio_type_override)
+        if radio_type == "doodlelabs":
+            self._doodlelabs_detail()
+            return
+        if radio_type != "silvus":
+            log.write("[yellow]No radios defined in topology.[/]")
+            return
         sys_radios = self.ctx.topo.get("silvus_radios", {}).get("radios", {})
         if not sys_radios:
             log.write("[yellow]No Silvus radios defined in topology.[/]")
@@ -673,6 +827,133 @@ class MonitorScreen(ModalScreen):
             if all_err:
                 log.write(
                     f"\n[yellow]All radios unreachable — is the {mgmt_subnet} route set? (press F3)[/]"
+                )
+            else:
+                log.write(
+                    "\n[dim]Press 'z' to see which robot currently has each radio.[/]"
+                )
+
+        def bg():
+            result = do_query()
+            self.app.call_from_thread(on_done, result)
+
+        threading.Thread(target=bg, daemon=True).start()
+
+    def _doodlelabs_detail(self):
+        """Doodle Labs equivalent of action_silvus_detail — queries all configured
+        Doodle Labs radios directly via HTTPS and renders an RSSI matrix plus
+        batman-adv mesh routing."""
+        log = self.query_one("#monitor_log", RichLog)
+        dl_radios = self.ctx.topo.get("doodlelabs_radios", {}).get("radios", {})
+        if not dl_radios:
+            log.write("[yellow]No Doodle Labs radios defined in topology.[/]")
+            return
+        log.write("[dim]Querying Doodle Labs radios (direct HTTPS)...[/]")
+
+        def do_query():
+            return get_doodlelabs_radio_details(self.ctx.topo)
+
+        def on_done(details):
+            if not details:
+                log.write("[red]No radio data returned.[/]")
+                return
+
+            # Build bssid -> radio_name reverse map (batman peer ID is BSSID)
+            bssid_to_name = {}
+            for rname, info in details.items():
+                b = info.get("bssid")
+                if b:
+                    bssid_to_name[b.lower()] = rname
+
+            names = sorted(details.keys())
+            col_w = max(len(n) for n in names) + 2
+
+            # ---- RSSI Matrix (from sta_stats) ----
+            log.write("\n[bold]Doodle Labs RSSI Link Quality:[/]")
+            header = " " * (col_w + 2) + "".join(f"{n:>{col_w}}" for n in names)
+            log.write(f"  [dim]{header}[/]")
+
+            for src in names:
+                info = details[src]
+                if info.get("error"):
+                    log.write(
+                        f"  [red]{src:<{col_w}}[/]  [red](unreachable: {info['error'][:40]})[/]"
+                    )
+                    continue
+                row = f"  [cyan]{src:<{col_w}}[/]"
+                # sta_stats: list of {mac, rssi, mcs, ...} per direct peer
+                rssi_by_peer = {}
+                for p in info.get("sta_stats") or []:
+                    mac = (p.get("mac") or "").lower()
+                    rssi = p.get("rssi")
+                    if mac and rssi is not None:
+                        rssi_by_peer[mac] = rssi
+                # mesh_stats: list of {orig_address, tq, hop_status}
+                tq_by_peer = {}
+                for m in info.get("mesh_stats") or []:
+                    mac = (m.get("orig_address") or "").lower()
+                    tq = m.get("tq")
+                    if mac and tq is not None:
+                        tq_by_peer[mac] = tq
+
+                for dst in names:
+                    if src == dst:
+                        row += f"{'---':>{col_w}}"
+                        continue
+                    dst_bssid = (details[dst].get("bssid") or "").lower()
+                    val = rssi_by_peer.get(dst_bssid)
+                    if val is not None:
+                        if val > -60:
+                            cell = f"[green]{val}dBm[/]"
+                        elif val > -75:
+                            cell = f"[yellow]{val}dBm[/]"
+                        else:
+                            cell = f"[red]{val}dBm[/]"
+                        row += f"{cell:>{col_w}}"
+                    elif dst_bssid and dst_bssid in tq_by_peer:
+                        tq = tq_by_peer[dst_bssid]
+                        pct = int(tq * 100 / 255)
+                        color = (
+                            "green" if tq > 200 else "yellow" if tq > 128 else "red"
+                        )
+                        cell = f"[{color}]TQ{pct}%[/]"
+                        row += f"{cell:>{col_w}}"
+                    else:
+                        row += f"[dim]{'?':>{col_w}}[/]"
+                log.write(row)
+
+            # ---- Mesh Topology (batman-adv) ----
+            log.write("\n[bold]Mesh Routing (batman-adv, per radio):[/]")
+            for rname in names:
+                info = details[rname]
+                if info.get("error"):
+                    continue
+                bat_v = info.get("battery_v")
+                bat_s = f"  bat={bat_v:.2f}V" if bat_v is not None else ""
+                sig = info.get("signal")
+                sig_s = f"  signal={sig}dBm" if sig is not None else ""
+                mesh = info.get("mesh_stats") or []
+                if mesh:
+                    parts = []
+                    for m in mesh:
+                        mac = (m.get("orig_address") or "").lower()
+                        tq = m.get("tq")
+                        hop = m.get("hop_status", "")
+                        pct = int(tq * 100 / 255) if tq is not None else 0
+                        label = bssid_to_name.get(mac, mac)
+                        parts.append(f"{label}(TQ={pct}%, {hop})")
+                    tree_str = ", ".join(parts)
+                else:
+                    tree_str = "—"
+                log.write(
+                    f"  [cyan]{rname}[/]{bat_s}{sig_s}: [{tree_str}]"
+                )
+
+            all_err = all(d.get("error") for d in details.values())
+            if all_err:
+                log.write(
+                    "\n[yellow]All radios unreachable — check USB connection "
+                    "or 10.223.0.0/16 mesh route (press F3).[/]"
                 )
             else:
                 log.write(

--- a/dcist_launch_system/src/dcist_launch_system/tui/screens/monitor.py
+++ b/dcist_launch_system/src/dcist_launch_system/tui/screens/monitor.py
@@ -143,7 +143,9 @@ class MonitorScreen(ModalScreen):
             machines = [
                 m for m in self.ctx.runtime_config.values() if m.get("online", False)
             ]
-            radio_type = get_active_radio_type(self.ctx.topo, self.ctx.radio_type_override)
+            radio_type = get_active_radio_type(
+                self.ctx.topo, self.ctx.radio_type_override
+            )
             silvus_ips = None
             dl_ips = None
             dl_creds = None
@@ -153,9 +155,7 @@ class MonitorScreen(ModalScreen):
                     r["mgmt_ip"] for r in sys_radios.values() if "mgmt_ip" in r
                 ]
             elif radio_type == "doodlelabs":
-                dl_radios = self.ctx.topo.get("doodlelabs_radios", {}).get(
-                    "radios", {}
-                )
+                dl_radios = self.ctx.topo.get("doodlelabs_radios", {}).get("radios", {})
                 dl_ips = [r["ip"] for r in dl_radios.values() if "ip" in r]
                 # Use first radio's creds (assume uniform across fleet)
                 for r in dl_radios.values():
@@ -383,7 +383,9 @@ class MonitorScreen(ModalScreen):
 
         def do_check():
             machines = list(self.ctx.runtime_config.values())
-            radio_type = get_active_radio_type(self.ctx.topo, self.ctx.radio_type_override)
+            radio_type = get_active_radio_type(
+                self.ctx.topo, self.ctx.radio_type_override
+            )
             silvus_mgmt_ips = []
             dl_ips = []
             dl_creds = None
@@ -393,9 +395,7 @@ class MonitorScreen(ModalScreen):
                     r["mgmt_ip"] for r in sys_radios.values() if "mgmt_ip" in r
                 ]
             elif radio_type == "doodlelabs":
-                dl_radios = self.ctx.topo.get("doodlelabs_radios", {}).get(
-                    "radios", {}
-                )
+                dl_radios = self.ctx.topo.get("doodlelabs_radios", {}).get("radios", {})
                 dl_ips = [r["ip"] for r in dl_radios.values() if "ip" in r]
                 for r in dl_radios.values():
                     dl_creds = (
@@ -449,13 +449,11 @@ class MonitorScreen(ModalScreen):
                 )
 
             has_radio = any(r for _, _, r in results if r)
-            radio_type = get_active_radio_type(self.ctx.topo, self.ctx.radio_type_override)
+            radio_type = get_active_radio_type(
+                self.ctx.topo, self.ctx.radio_type_override
+            )
             if has_radio:
-                label = (
-                    "Doodle Labs"
-                    if radio_type == "doodlelabs"
-                    else "Silvus"
-                )
+                label = "Doodle Labs" if radio_type == "doodlelabs" else "Silvus"
                 log.write(f"\n[bold]{label} Radio Link Quality:[/]")
                 radio_assignment = []  # (machine_name, node_id_or_bssid)
                 for m, _, radio in sorted(results, key=lambda x: x[0]["name"]):
@@ -505,7 +503,7 @@ class MonitorScreen(ModalScreen):
 
                 if radio_assignment:
                     id_label = "BSSID" if radio_type == "doodlelabs" else "node"
-                    log.write(f"\n[bold]Radio Assignment (current):[/]")
+                    log.write("\n[bold]Radio Assignment (current):[/]")
                     for mname, rid in radio_assignment:
                         log.write(f"  [cyan]{mname:12s}[/] → {id_label} {rid}")
                     log.write(
@@ -594,9 +592,7 @@ class MonitorScreen(ModalScreen):
                     )
             return results
 
-        data_subnet = (
-            "192.168.153.x" if radio_type == "doodlelabs" else "192.168.100.x"
-        )
+        data_subnet = "192.168.153.x" if radio_type == "doodlelabs" else "192.168.100.x"
 
         def on_done(results):
             log.write(f"\n[bold]{label} Route ({mgmt_subnet}):[/]")
@@ -659,10 +655,7 @@ class MonitorScreen(ModalScreen):
             if local_no_iface:
                 # Show a template command for local even when the interface
                 # isn't present yet (USB unplugged, or not auto-configured).
-                log.write(
-                    "\n[bold yellow]Local has no "
-                    f"{data_subnet} interface.[/]"
-                )
+                log.write(f"\n[bold yellow]Local has no {data_subnet} interface.[/]")
                 if radio_type == "doodlelabs":
                     log.write(
                         "  [dim]Plug in the Doodle Labs radio via USB-ethernet, "
@@ -673,21 +666,15 @@ class MonitorScreen(ModalScreen):
                         "  [dim]Connect to the Silvus network, then find the "
                         "interface name:[/]"
                     )
-                log.write(
-                    f"    [cyan]ip -o addr show | grep '{data_subnet[:-1]}'[/]"
-                )
+                log.write(f"    [cyan]ip -o addr show | grep '{data_subnet[:-1]}'[/]")
                 log.write(
                     "  [dim]Then add the route (replace <iface> with what you "
                     "found above):[/]"
                 )
+                log.write(f"    [cyan]sudo ip route add {mgmt_subnet} dev <iface>[/]")
+                log.write("  [dim]For permanent route via NetworkManager:[/]")
                 log.write(
-                    f"    [cyan]sudo ip route add {mgmt_subnet} dev <iface>[/]"
-                )
-                log.write(
-                    "  [dim]For permanent route via NetworkManager:[/]"
-                )
-                log.write(
-                    f"    [cyan]conn=$(nmcli -f NAME,DEVICE con show "
+                    "    [cyan]conn=$(nmcli -f NAME,DEVICE con show "
                     "| grep <iface> | awk '{print $1}')[/]"
                 )
                 log.write(
@@ -913,9 +900,7 @@ class MonitorScreen(ModalScreen):
                     elif dst_bssid and dst_bssid in tq_by_peer:
                         tq = tq_by_peer[dst_bssid]
                         pct = int(tq * 100 / 255)
-                        color = (
-                            "green" if tq > 200 else "yellow" if tq > 128 else "red"
-                        )
+                        color = "green" if tq > 200 else "yellow" if tq > 128 else "red"
                         cell = f"[{color}]TQ{pct}%[/]"
                         row += f"{cell:>{col_w}}"
                     else:
@@ -945,9 +930,7 @@ class MonitorScreen(ModalScreen):
                     tree_str = ", ".join(parts)
                 else:
                     tree_str = "—"
-                log.write(
-                    f"  [cyan]{rname}[/]{bat_s}{sig_s}: [{tree_str}]"
-                )
+                log.write(f"  [cyan]{rname}[/]{bat_s}{sig_s}: [{tree_str}]")
 
             all_err = all(d.get("error") for d in details.values())
             if all_err:

--- a/network_diagnostics/config/topology.yaml
+++ b/network_diagnostics/config/topology.yaml
@@ -13,7 +13,7 @@ machines:
   russell: {role: base_station, desc: Aaron's laptop, addresses: {mit_wifi: 10.29.129.166, silvus: 192.168.100.101}}
   bonsai: {role: base_station, desc: RRG dev computer, addresses: {penn_wifi: 192.168.129.217}}
   willow: {role: base_station, desc: RRG base station, addresses: {mit_wifi: 10.31.172.204, silvus: 192.168.100.100}}
-  sequia: {role: base_station, desc: Sequia base station, addresses: {mit_wifi: 10.29.166.252, silvus: 192.168.100.105}}
+  sequoia: {role: base_station, desc: Sequoia base station, addresses: {mit_wifi: 10.29.166.252, silvus: 192.168.100.105}}
 silvus_radios:
   mgmt_subnet: 172.20.0.0/16
   api_endpoint: /cgi-bin/streamscape_api
@@ -26,6 +26,15 @@ silvus_radios:
     # radio_XXXXXX: { mgmt_ip: "172.20.x.x", node_id: XXXXXX }
   udp_telemetry:
     listen_port: 5100
+doodlelabs_radios:
+  # Doodle Labs Mesh Rider wearable radio
+  # API: JSON-RPC over HTTPS at /ubus (OpenWrt ubus)
+  # Default config IP: 192.168.153.1, mesh IP: 10.223.x.y/16
+  radios:
+    dl_wearable_1: {ip: 192.168.153.1, user: user, password: DoodleSmartRadio}
+    # To add the second radio, find its mesh IP via: ssh root@192.168.153.1 'batctl tg'
+    # Then: sudo ip route add 10.223.0.0/16 dev enx9c69d329c4cc
+    # dl_radio_2: {ip: "10.223.x.y", user: user, password: DoodleSmartRadio}
 zenoh:
   port: 7447
   connect_network: silvus

--- a/network_diagnostics/scripts/doodlelabs_mesh_viz.py
+++ b/network_diagnostics/scripts/doodlelabs_mesh_viz.py
@@ -14,25 +14,24 @@ Usage:
 
 import argparse
 import json
-import os
+import platform
+import socket
 import ssl
+import subprocess
 import sys
 import threading
 import time
 import urllib.request
 import webbrowser
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-
-import platform
-import socket
-import subprocess
 
 import yaml
 
 # ---------------------------------------------------------------------------
 # Local machine info
 # ---------------------------------------------------------------------------
+
 
 def _get_local_machine_info():
     """Detect this machine's identity and Doodle Labs interface."""
@@ -47,7 +46,8 @@ def _get_local_machine_info():
     # Find the interface with a 192.168.153.x address
     try:
         result = subprocess.run(
-            ["ip", "-o", "addr", "show"], capture_output=True, text=True)
+            ["ip", "-o", "addr", "show"], capture_output=True, text=True
+        )
         for line in result.stdout.strip().split("\n"):
             if "192.168.153." in line:
                 parts = line.split()
@@ -74,9 +74,11 @@ def _get_local_machine_info():
                 k, v = line.split(":")
                 meminfo[k.strip()] = int(v.strip().split()[0]) * 1024
             info["mem_total"] = meminfo.get("MemTotal", 0)
-            info["mem_free"] = (meminfo.get("MemFree", 0)
-                                + meminfo.get("Buffers", 0)
-                                + meminfo.get("Cached", 0))
+            info["mem_free"] = (
+                meminfo.get("MemFree", 0)
+                + meminfo.get("Buffers", 0)
+                + meminfo.get("Cached", 0)
+            )
     except Exception:
         pass
     return info
@@ -94,12 +96,17 @@ NULL_TOKEN = "00000000000000000000000000000000"
 
 
 def _rpc(ip, token, obj, method, args=None):
-    payload = json.dumps({
-        "jsonrpc": "2.0", "id": 1, "method": "call",
-        "params": [token, obj, method, args or {}],
-    }).encode()
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "call",
+            "params": [token, obj, method, args or {}],
+        }
+    ).encode()
     req = urllib.request.Request(
-        f"https://{ip}/ubus", data=payload,
+        f"https://{ip}/ubus",
+        data=payload,
         headers={"Content-Type": "application/json"},
     )
     with urllib.request.urlopen(req, timeout=5, context=_ssl_ctx) as resp:
@@ -113,8 +120,9 @@ def _rpc(ip, token, obj, method, args=None):
 
 
 def _login(ip, user, password):
-    code, data = _rpc(ip, NULL_TOKEN, "session", "login",
-                      {"username": user, "password": password})
+    code, data = _rpc(
+        ip, NULL_TOKEN, "session", "login", {"username": user, "password": password}
+    )
     if code == 0 and data:
         return data.get("ubus_rpc_session", "")
     return ""
@@ -142,8 +150,9 @@ def query_radio(ip, user, password):
             info["uptime"] = sysinfo.get("uptime", 0)
             mem = sysinfo.get("memory", {})
             info["mem_total"] = mem.get("total", 0)
-            info["mem_free"] = (mem.get("free", 0) + mem.get("buffered", 0)
-                                + mem.get("cached", 0))
+            info["mem_free"] = (
+                mem.get("free", 0) + mem.get("buffered", 0) + mem.get("cached", 0)
+            )
 
         code, iw = _rpc(ip, token, "iwinfo", "info", {"device": "wlan0"})
         if code == 0 and iw:
@@ -158,8 +167,13 @@ def query_radio(ip, user, password):
             info["noise"] = iw.get("noise")
             info["bitrate"] = iw.get("bitrate")
 
-        code, data = _rpc(ip, token, "file", "read",
-                          {"path": "/tmp/linkstate_current.json", "base64": False})
+        code, data = _rpc(
+            ip,
+            token,
+            "file",
+            "read",
+            {"path": "/tmp/linkstate_current.json", "base64": False},
+        )
         if code == 0 and data and data.get("data"):
             try:
                 ls = json.loads(data["data"])
@@ -169,9 +183,13 @@ def query_radio(ip, user, password):
             except json.JSONDecodeError:
                 pass
 
-        code, data = _rpc(ip, token, "file", "exec",
-                          {"command": "cat",
-                           "params": ["/tmp/run/pancake.txt"]})
+        code, data = _rpc(
+            ip,
+            token,
+            "file",
+            "exec",
+            {"command": "cat", "params": ["/tmp/run/pancake.txt"]},
+        )
         if code == 0 and data and data.get("stdout"):
             try:
                 pancake = json.loads(data["stdout"])
@@ -185,8 +203,9 @@ def query_radio(ip, user, password):
                 pass
 
         for field in ("latitude", "longitude", "altitude"):
-            code, data = _rpc(ip, token, "file", "read",
-                              {"path": f"/var/run/gps/{field}"})
+            code, data = _rpc(
+                ip, token, "file", "read", {"path": f"/var/run/gps/{field}"}
+            )
             if code == 0 and data and data.get("data"):
                 val = data["data"].strip()
                 if val and val != "0":
@@ -200,6 +219,7 @@ def query_radio(ip, user, password):
 # ---------------------------------------------------------------------------
 # Topology poller
 # ---------------------------------------------------------------------------
+
 
 class TopologyState:
     def __init__(self, topology_path):
@@ -245,11 +265,13 @@ class TopologyState:
 
         # Ethernet link from this machine to the directly-connected radio
         if local_connected_radio:
-            edges.append({
-                "from": "_this_machine",
-                "to": local_connected_radio,
-                "type": "ethernet",
-            })
+            edges.append(
+                {
+                    "from": "_this_machine",
+                    "to": local_connected_radio,
+                    "type": "ethernet",
+                }
+            )
 
         # Build edges from sta_stats and mesh_stats
         seen_edges = set()
@@ -263,15 +285,17 @@ class TopologyState:
                 key = tuple(sorted([src, dst]))
                 if key not in seen_edges:
                     seen_edges.add(key)
-                    edges.append({
-                        "from": src,
-                        "to": dst,
-                        "rssi": peer.get("rssi"),
-                        "rssi_ant": peer.get("rssi_ant", []),
-                        "mcs": peer.get("mcs"),
-                        "pl_ratio": peer.get("pl_ratio", 0),
-                        "type": "direct",
-                    })
+                    edges.append(
+                        {
+                            "from": src,
+                            "to": dst,
+                            "rssi": peer.get("rssi"),
+                            "rssi_ant": peer.get("rssi_ant", []),
+                            "mcs": peer.get("mcs"),
+                            "pl_ratio": peer.get("pl_ratio", 0),
+                            "type": "direct",
+                        }
+                    )
 
             for mesh_node in node.get("mesh_stats", []):
                 mac = mesh_node.get("orig_address", "").lower()
@@ -280,14 +304,16 @@ class TopologyState:
                 key = tuple(sorted([src, dst]))
                 if key not in seen_edges:
                     seen_edges.add(key)
-                    edges.append({
-                        "from": src,
-                        "to": dst,
-                        "tq": mesh_node.get("tq"),
-                        "hop_status": hop,
-                        "last_seen_ms": mesh_node.get("last_seen_msecs"),
-                        "type": "mesh",
-                    })
+                    edges.append(
+                        {
+                            "from": src,
+                            "to": dst,
+                            "tq": mesh_node.get("tq"),
+                            "hop_status": hop,
+                            "last_seen_ms": mesh_node.get("last_seen_msecs"),
+                            "type": "mesh",
+                        }
+                    )
 
         with self.lock:
             self.data = {
@@ -905,6 +931,7 @@ requestAnimationFrame(draw);
 # HTTP server
 # ---------------------------------------------------------------------------
 
+
 class Handler(BaseHTTPRequestHandler):
     state = None  # set in main
 
@@ -912,21 +939,22 @@ class Handler(BaseHTTPRequestHandler):
         pass  # quiet
 
     def do_GET(self):
-        if self.path == '/api/topology':
+        if self.path == "/api/topology":
             data = self.state.get()
             body = json.dumps(data).encode()
             self.send_response(200)
-            self.send_header('Content-Type', 'application/json')
-            self.send_header('Content-Length', len(body))
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", len(body))
             self.end_headers()
             self.wfile.write(body)
-        elif self.path in ('/', '/index.html'):
+        elif self.path in ("/", "/index.html"):
             body = HTML_PAGE.replace(
-                'REFRESH_INTERVAL', str(self.refresh_interval),
+                "REFRESH_INTERVAL",
+                str(self.refresh_interval),
             ).encode()
             self.send_response(200)
-            self.send_header('Content-Type', 'text/html')
-            self.send_header('Content-Length', len(body))
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", len(body))
             self.end_headers()
             self.wfile.write(body)
         else:
@@ -934,17 +962,18 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description='Doodle Labs mesh topology visualizer')
-    parser.add_argument('--port', type=int, default=8780)
-    parser.add_argument('--refresh', type=int, default=5,
-                        help='poll interval in seconds')
-    parser.add_argument('--no-open', action='store_true',
-                        help="don't auto-open browser")
+    parser = argparse.ArgumentParser(description="Doodle Labs mesh topology visualizer")
+    parser.add_argument("--port", type=int, default=8780)
+    parser.add_argument(
+        "--refresh", type=int, default=5, help="poll interval in seconds"
+    )
+    parser.add_argument(
+        "--no-open", action="store_true", help="don't auto-open browser"
+    )
     args = parser.parse_args()
 
     script_dir = Path(__file__).resolve().parent
-    topology = script_dir.parent / 'config' / 'topology.yaml'
+    topology = script_dir.parent / "config" / "topology.yaml"
     if not topology.exists():
         print(f"topology.yaml not found at {topology}", file=sys.stderr)
         sys.exit(1)
@@ -958,16 +987,15 @@ def main():
     print(f"  Found {len(data['nodes'])} node(s), {len(data['edges'])} link(s)")
 
     # Start background poller
-    t = threading.Thread(target=poller_loop, args=(state, args.refresh),
-                         daemon=True)
+    t = threading.Thread(target=poller_loop, args=(state, args.refresh), daemon=True)
     t.start()
 
     # Start HTTP server
     Handler.state = state
     Handler.refresh_interval = args.refresh
-    server = HTTPServer(('127.0.0.1', args.port), Handler)
+    server = HTTPServer(("127.0.0.1", args.port), Handler)
 
-    url = f'http://localhost:{args.port}'
+    url = f"http://localhost:{args.port}"
     print(f"Serving at {url}  (refresh every {args.refresh}s)")
     print("Press Ctrl+C to stop.")
 
@@ -980,5 +1008,5 @@ def main():
         print("\nStopped.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/network_diagnostics/scripts/doodlelabs_mesh_viz.py
+++ b/network_diagnostics/scripts/doodlelabs_mesh_viz.py
@@ -1,0 +1,984 @@
+#!/usr/bin/env python3
+"""
+Doodle Labs Mesh Rider — live mesh topology visualizer.
+
+Runs a local web server that queries all radios from topology.yaml and
+displays an interactive force-directed graph in the browser.
+
+Usage:
+    ./doodlelabs_mesh_viz.py                  # default port 8780
+    ./doodlelabs_mesh_viz.py --port 9000
+    ./doodlelabs_mesh_viz.py --no-open        # don't auto-open browser
+    ./doodlelabs_mesh_viz.py --refresh 10     # poll interval in seconds
+"""
+
+import argparse
+import json
+import os
+import ssl
+import sys
+import threading
+import time
+import urllib.request
+import webbrowser
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+
+import platform
+import socket
+import subprocess
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Local machine info
+# ---------------------------------------------------------------------------
+
+def _get_local_machine_info():
+    """Detect this machine's identity and Doodle Labs interface."""
+    info = {
+        "name": "_this_machine",
+        "is_local": True,
+        "reachable": True,
+        "hostname": socket.gethostname(),
+        "model": f"{platform.system()} {platform.machine()}",
+        "ip": "",
+    }
+    # Find the interface with a 192.168.153.x address
+    try:
+        result = subprocess.run(
+            ["ip", "-o", "addr", "show"], capture_output=True, text=True)
+        for line in result.stdout.strip().split("\n"):
+            if "192.168.153." in line:
+                parts = line.split()
+                info["dl_interface"] = parts[1]
+                # Extract our IP from the addr field (e.g. 192.168.153.100/24)
+                for p in parts:
+                    if p.startswith("192.168.153."):
+                        info["ip"] = p.split("/")[0]
+                        break
+                break
+    except Exception:
+        pass
+    # Uptime
+    try:
+        with open("/proc/uptime") as f:
+            info["uptime"] = int(float(f.read().split()[0]))
+    except Exception:
+        pass
+    # Memory
+    try:
+        with open("/proc/meminfo") as f:
+            meminfo = {}
+            for line in f:
+                k, v = line.split(":")
+                meminfo[k.strip()] = int(v.strip().split()[0]) * 1024
+            info["mem_total"] = meminfo.get("MemTotal", 0)
+            info["mem_free"] = (meminfo.get("MemFree", 0)
+                                + meminfo.get("Buffers", 0)
+                                + meminfo.get("Cached", 0))
+    except Exception:
+        pass
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Radio API
+# ---------------------------------------------------------------------------
+
+_ssl_ctx = ssl.create_default_context()
+_ssl_ctx.check_hostname = False
+_ssl_ctx.verify_mode = ssl.CERT_NONE
+
+NULL_TOKEN = "00000000000000000000000000000000"
+
+
+def _rpc(ip, token, obj, method, args=None):
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "call",
+        "params": [token, obj, method, args or {}],
+    }).encode()
+    req = urllib.request.Request(
+        f"https://{ip}/ubus", data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=5, context=_ssl_ctx) as resp:
+        data = json.loads(resp.read())
+    result = data.get("result", [])
+    if len(result) >= 2:
+        return result[0], result[1]
+    if len(result) == 1:
+        return result[0], None
+    return -1, None
+
+
+def _login(ip, user, password):
+    code, data = _rpc(ip, NULL_TOKEN, "session", "login",
+                      {"username": user, "password": password})
+    if code == 0 and data:
+        return data.get("ubus_rpc_session", "")
+    return ""
+
+
+def query_radio(ip, user, password):
+    """Query a single radio. Returns a dict with all available info."""
+    info = {"ip": ip, "reachable": False}
+    try:
+        token = _login(ip, user, password)
+        if not token:
+            info["error"] = "auth failed"
+            return info
+        info["reachable"] = True
+
+        code, board = _rpc(ip, token, "system", "board", {})
+        if code == 0 and board:
+            info["hostname"] = board.get("hostname", "")
+            info["model"] = board.get("model", "")
+            rel = board.get("release", {})
+            info["firmware"] = rel.get("description", rel.get("version", ""))
+
+        code, sysinfo = _rpc(ip, token, "system", "info", {})
+        if code == 0 and sysinfo:
+            info["uptime"] = sysinfo.get("uptime", 0)
+            mem = sysinfo.get("memory", {})
+            info["mem_total"] = mem.get("total", 0)
+            info["mem_free"] = (mem.get("free", 0) + mem.get("buffered", 0)
+                                + mem.get("cached", 0))
+
+        code, iw = _rpc(ip, token, "iwinfo", "info", {"device": "wlan0"})
+        if code == 0 and iw:
+            info["bssid"] = iw.get("bssid", "")
+            info["ssid"] = iw.get("ssid", "")
+            info["mode"] = iw.get("mode", "")
+            info["frequency"] = iw.get("frequency")
+            info["channel"] = iw.get("channel")
+            info["htmode"] = iw.get("htmode", "")
+            info["txpower"] = iw.get("txpower")
+            info["signal"] = iw.get("signal")
+            info["noise"] = iw.get("noise")
+            info["bitrate"] = iw.get("bitrate")
+
+        code, data = _rpc(ip, token, "file", "read",
+                          {"path": "/tmp/linkstate_current.json", "base64": False})
+        if code == 0 and data and data.get("data"):
+            try:
+                ls = json.loads(data["data"])
+                info["sta_stats"] = ls.get("sta_stats", [])
+                info["mesh_stats"] = ls.get("mesh_stats", [])
+                info["activity"] = ls.get("activity")
+            except json.JSONDecodeError:
+                pass
+
+        code, data = _rpc(ip, token, "file", "exec",
+                          {"command": "cat",
+                           "params": ["/tmp/run/pancake.txt"]})
+        if code == 0 and data and data.get("stdout"):
+            try:
+                pancake = json.loads(data["stdout"])
+                temp = pancake.get("Temperature", pancake.get("temperature"))
+                vin = pancake.get("VIN VOLTAGE", pancake.get("vin_voltage"))
+                if temp is not None:
+                    info["temperature"] = float(temp)
+                if vin is not None:
+                    info["battery_v"] = float(vin) / 20.2
+            except (json.JSONDecodeError, ValueError, TypeError):
+                pass
+
+        for field in ("latitude", "longitude", "altitude"):
+            code, data = _rpc(ip, token, "file", "read",
+                              {"path": f"/var/run/gps/{field}"})
+            if code == 0 and data and data.get("data"):
+                val = data["data"].strip()
+                if val and val != "0":
+                    info.setdefault("gps", {})[field] = val
+
+    except Exception as e:
+        info["error"] = str(e)
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Topology poller
+# ---------------------------------------------------------------------------
+
+class TopologyState:
+    def __init__(self, topology_path):
+        self.topology_path = topology_path
+        self.lock = threading.Lock()
+        self.data = {"nodes": [], "edges": [], "ts": 0}
+
+    def poll(self):
+        with open(self.topology_path) as f:
+            cfg = yaml.safe_load(f)
+        radios_cfg = cfg.get("doodlelabs_radios", {}).get("radios", {})
+
+        nodes = []
+        edges = []
+        bssid_to_name = {}  # bssid -> config name
+
+        # Add local machine node
+        local = _get_local_machine_info()
+        nodes.append(local)
+        local_connected_radio = None  # first radio at 192.168.153.x
+
+        for name, rcfg in sorted(radios_cfg.items()):
+            ip = rcfg.get("ip", "")
+            if not ip:
+                continue
+            user = rcfg.get("user", "user")
+            password = rcfg.get("password", "DoodleSmartRadio")
+
+            info = query_radio(ip, user, password)
+            info["name"] = name
+
+            bssid = info.get("bssid", "").lower()
+            if bssid:
+                bssid_to_name[bssid] = name
+
+            nodes.append(info)
+
+            # The radio at 192.168.153.1 is the one physically connected
+            # to this machine via USB-ethernet
+            if ip.startswith("192.168.153.") and info["reachable"]:
+                if local_connected_radio is None:
+                    local_connected_radio = name
+
+        # Ethernet link from this machine to the directly-connected radio
+        if local_connected_radio:
+            edges.append({
+                "from": "_this_machine",
+                "to": local_connected_radio,
+                "type": "ethernet",
+            })
+
+        # Build edges from sta_stats and mesh_stats
+        seen_edges = set()
+        for node in nodes:
+            if node.get("is_local"):
+                continue
+            src = node["name"]
+            for peer in node.get("sta_stats", []):
+                mac = peer.get("mac", "").lower()
+                dst = bssid_to_name.get(mac, mac)
+                key = tuple(sorted([src, dst]))
+                if key not in seen_edges:
+                    seen_edges.add(key)
+                    edges.append({
+                        "from": src,
+                        "to": dst,
+                        "rssi": peer.get("rssi"),
+                        "rssi_ant": peer.get("rssi_ant", []),
+                        "mcs": peer.get("mcs"),
+                        "pl_ratio": peer.get("pl_ratio", 0),
+                        "type": "direct",
+                    })
+
+            for mesh_node in node.get("mesh_stats", []):
+                mac = mesh_node.get("orig_address", "").lower()
+                dst = bssid_to_name.get(mac, mac)
+                hop = mesh_node.get("hop_status", "")
+                key = tuple(sorted([src, dst]))
+                if key not in seen_edges:
+                    seen_edges.add(key)
+                    edges.append({
+                        "from": src,
+                        "to": dst,
+                        "tq": mesh_node.get("tq"),
+                        "hop_status": hop,
+                        "last_seen_ms": mesh_node.get("last_seen_msecs"),
+                        "type": "mesh",
+                    })
+
+        with self.lock:
+            self.data = {
+                "nodes": nodes,
+                "edges": edges,
+                "ts": time.time(),
+            }
+
+    def get(self):
+        with self.lock:
+            return self.data
+
+
+def poller_loop(state, interval):
+    while True:
+        try:
+            state.poll()
+        except Exception as e:
+            print(f"[poller] error: {e}", file=sys.stderr)
+        time.sleep(interval)
+
+
+# ---------------------------------------------------------------------------
+# HTML page
+# ---------------------------------------------------------------------------
+
+HTML_PAGE = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Doodle Labs Mesh Visualizer</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace;
+    background: #0d1117; color: #c9d1d9;
+  }
+  #header {
+    padding: 12px 20px; background: #161b22; border-bottom: 1px solid #30363d;
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  #header h1 { font-size: 16px; font-weight: 600; color: #58a6ff; }
+  #header .status { font-size: 12px; color: #8b949e; }
+  #header .status .dot {
+    display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+    margin-right: 4px; vertical-align: middle;
+  }
+  #header .controls { display: flex; align-items: center; gap: 10px; }
+  #header .controls button {
+    background: #21262d; border: 1px solid #30363d; color: #c9d1d9;
+    padding: 4px 10px; border-radius: 4px; cursor: pointer; font-size: 12px;
+  }
+  #header .controls button:hover { background: #30363d; }
+  #header .controls button.active { background: #238636; border-color: #238636; }
+  #header .controls select {
+    background: #21262d; border: 1px solid #30363d; color: #c9d1d9;
+    padding: 3px 6px; border-radius: 4px; font-size: 12px;
+  }
+  #header .status .dot.live { background: #3fb950; }
+  #header .status .dot.stale { background: #d29922; }
+  #main { display: flex; height: calc(100vh - 49px); }
+  #graph { flex: 1; position: relative; }
+  #graph canvas { display: block; }
+  #sidebar {
+    width: 320px; background: #161b22; border-left: 1px solid #30363d;
+    overflow-y: auto; padding: 16px; font-size: 13px;
+  }
+  #sidebar h2 { font-size: 14px; color: #58a6ff; margin-bottom: 12px; }
+  #sidebar .empty { color: #484f58; font-style: italic; }
+  .node-card {
+    background: #0d1117; border: 1px solid #30363d; border-radius: 6px;
+    padding: 10px 12px; margin-bottom: 10px;
+  }
+  .node-card.selected { border-color: #58a6ff; }
+  .node-card .name { font-weight: 600; color: #f0f6fc; margin-bottom: 4px; }
+  .node-card .field { color: #8b949e; margin-bottom: 2px; }
+  .node-card .field span { color: #c9d1d9; }
+  .badge {
+    display: inline-block; padding: 1px 6px; border-radius: 10px;
+    font-size: 11px; font-weight: 600;
+  }
+  .badge.green { background: #238636; color: #fff; }
+  .badge.yellow { background: #9e6a03; color: #fff; }
+  .badge.red { background: #da3633; color: #fff; }
+  .badge.gray { background: #30363d; color: #8b949e; }
+  .edge-info {
+    background: #0d1117; border: 1px solid #30363d; border-radius: 6px;
+    padding: 10px 12px; margin-bottom: 10px;
+  }
+  .edge-info .label { font-weight: 600; color: #f0f6fc; margin-bottom: 4px; }
+  #legend {
+    position: absolute; bottom: 12px; left: 12px; background: #161b22e0;
+    border: 1px solid #30363d; border-radius: 6px; padding: 10px 14px;
+    font-size: 11px; color: #8b949e;
+  }
+  #legend .row { display: flex; align-items: center; margin-bottom: 3px; }
+  #legend .swatch {
+    width: 24px; height: 4px; border-radius: 2px; margin-right: 8px;
+  }
+</style>
+</head>
+<body>
+<div id="header">
+  <h1>Doodle Labs Mesh Topology</h1>
+  <div class="controls">
+    <button id="btnRefresh" onclick="manualRefresh()" title="Refresh now">Refresh</button>
+    <button id="btnPause" onclick="togglePause()" title="Pause/resume auto-refresh">Auto</button>
+    <select id="selInterval" onchange="changeInterval(this.value)" title="Auto-refresh interval">
+      <option value="3">3s</option>
+      <option value="5" selected>5s</option>
+      <option value="10">10s</option>
+      <option value="30">30s</option>
+      <option value="60">60s</option>
+    </select>
+    <div class="status">
+      <span class="dot live" id="statusDot"></span>
+      <span id="statusText">connecting...</span>
+    </div>
+  </div>
+</div>
+<div id="main">
+  <div id="graph"><canvas id="canvas"></canvas>
+    <div id="legend">
+      <div class="row"><div class="swatch" style="background:#3fb950"></div>RSSI &gt; -60 dBm (excellent)</div>
+      <div class="row"><div class="swatch" style="background:#d29922"></div>RSSI -60 to -75 dBm (good)</div>
+      <div class="row"><div class="swatch" style="background:#da3633"></div>RSSI &lt; -75 dBm (weak)</div>
+      <div class="row"><div class="swatch" style="background:#30363d; border: 1px dashed #484f58"></div>Mesh-only (no direct link)</div>
+      <div class="row"><div class="swatch" style="background:#8b949e"></div>Ethernet (USB-to-radio)</div>
+      <div style="margin-top:6px; font-size:10px">
+        <span style="display:inline-block;width:12px;height:12px;border-radius:50%;background:#0d1117;border:1.5px solid #58a6ff;vertical-align:middle;margin-right:4px"></span>Radio
+        <span style="display:inline-block;width:12px;height:12px;border-radius:2px;background:#0d1117;border:1.5px solid #da7;vertical-align:middle;margin-left:8px;margin-right:4px"></span>This machine
+      </div>
+    </div>
+  </div>
+  <div id="sidebar">
+    <h2>Nodes</h2>
+    <div id="nodeList"><div class="empty">waiting for data...</div></div>
+    <h2 style="margin-top:16px">Links</h2>
+    <div id="edgeList"><div class="empty">waiting for data...</div></div>
+  </div>
+</div>
+
+<script>
+// ---------------------------------------------------------------------------
+// Graph engine — simple force-directed layout on canvas
+// ---------------------------------------------------------------------------
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+
+let W, H;
+function resize() {
+  const r = canvas.parentElement.getBoundingClientRect();
+  W = canvas.width = r.width * devicePixelRatio;
+  H = canvas.height = r.height * devicePixelRatio;
+  canvas.style.width = r.width + 'px';
+  canvas.style.height = r.height + 'px';
+  ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+}
+resize();
+window.addEventListener('resize', resize);
+
+let nodes = [];  // {id, x, y, vx, vy, info}
+let edges = [];  // {source, target, data}
+let selected = null;  // node id
+let dragging = null;
+let mouse = {x: 0, y: 0};
+
+const NODE_RADIUS = 28;
+const SPRING_LEN = 180;
+const SPRING_K = 0.004;
+const REPULSION = 8000;
+const DAMPING = 0.85;
+const CENTER_PULL = 0.001;
+
+function rssiColor(rssi) {
+  if (rssi == null) return '#30363d';
+  if (rssi > -60) return '#3fb950';
+  if (rssi > -75) return '#d29922';
+  return '#da3633';
+}
+
+function tqColor(tq) {
+  if (tq == null) return '#30363d';
+  if (tq > 200) return '#3fb950';
+  if (tq > 128) return '#d29922';
+  return '#da3633';
+}
+
+function batteryBadge(v) {
+  if (v == null) return '';
+  if (v > 7.84) return 'green';
+  if (v > 7.39) return 'yellow';
+  return 'red';
+}
+
+function nodeColor(info) {
+  if (info.is_local) return '#ddaa77';
+  if (!info.reachable) return '#484f58';
+  if (info.battery_v != null && info.battery_v < 6.5) return '#da3633';
+  return '#58a6ff';
+}
+
+function tick() {
+  const cw = W / devicePixelRatio, ch = H / devicePixelRatio;
+  // Repulsion
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      let dx = nodes[j].x - nodes[i].x;
+      let dy = nodes[j].y - nodes[i].y;
+      let d2 = dx * dx + dy * dy;
+      if (d2 < 1) d2 = 1;
+      let f = REPULSION / d2;
+      let fx = f * dx / Math.sqrt(d2);
+      let fy = f * dy / Math.sqrt(d2);
+      nodes[i].vx -= fx; nodes[i].vy -= fy;
+      nodes[j].vx += fx; nodes[j].vy += fy;
+    }
+  }
+  // Springs
+  for (const e of edges) {
+    const a = nodes.find(n => n.id === e.source);
+    const b = nodes.find(n => n.id === e.target);
+    if (!a || !b) continue;
+    let dx = b.x - a.x, dy = b.y - a.y;
+    let dist = Math.sqrt(dx * dx + dy * dy) || 1;
+    let f = SPRING_K * (dist - SPRING_LEN);
+    let fx = f * dx / dist, fy = f * dy / dist;
+    a.vx += fx; a.vy += fy;
+    b.vx -= fx; b.vy -= fy;
+  }
+  // Center pull + integrate
+  for (const n of nodes) {
+    if (n.id === dragging) { n.vx = 0; n.vy = 0; continue; }
+    n.vx += (cw / 2 - n.x) * CENTER_PULL;
+    n.vy += (ch / 2 - n.y) * CENTER_PULL;
+    n.vx *= DAMPING; n.vy *= DAMPING;
+    n.x += n.vx; n.y += n.vy;
+    n.x = Math.max(NODE_RADIUS, Math.min(cw - NODE_RADIUS, n.x));
+    n.y = Math.max(NODE_RADIUS, Math.min(ch - NODE_RADIUS, n.y));
+  }
+}
+
+function draw() {
+  const cw = W / devicePixelRatio, ch = H / devicePixelRatio;
+  ctx.clearRect(0, 0, cw, ch);
+
+  // Edges
+  for (const e of edges) {
+    const a = nodes.find(n => n.id === e.source);
+    const b = nodes.find(n => n.id === e.target);
+    if (!a || !b) continue;
+
+    let color, width, dash;
+    if (e.data.type === 'ethernet') {
+      color = '#8b949e';
+      width = 2;
+      dash = [];
+    } else if (e.data.type === 'direct') {
+      color = rssiColor(e.data.rssi);
+      width = 2.5;
+      dash = [];
+    } else {
+      color = tqColor(e.data.tq);
+      width = 1.5;
+      dash = [6, 4];
+    }
+
+    ctx.beginPath();
+    ctx.setLineDash(dash);
+    ctx.strokeStyle = color;
+    ctx.lineWidth = width;
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Edge label
+    let label = '';
+    if (e.data.type === 'ethernet') {
+      label = 'USB-ethernet';
+    } else if (e.data.type === 'direct' && e.data.rssi != null) {
+      label = e.data.rssi + ' dBm';
+      if (e.data.mcs != null) label += ' / MCS ' + e.data.mcs;
+    } else if (e.data.tq != null) {
+      label = 'TQ ' + Math.round(e.data.tq * 100 / 255) + '%';
+      if (e.data.hop_status) label += ' / ' + e.data.hop_status;
+    }
+    if (label) {
+      const mx = (a.x + b.x) / 2, my = (a.y + b.y) / 2;
+      ctx.font = '10px monospace';
+      ctx.fillStyle = '#8b949e';
+      ctx.textAlign = 'center';
+      ctx.fillText(label, mx, my - 6);
+    }
+  }
+
+  // Nodes
+  for (const n of nodes) {
+    const isSel = n.id === selected;
+    const color = nodeColor(n.info);
+    const isLocal = n.info.is_local;
+
+    if (isLocal) {
+      // Rounded rectangle for this machine
+      const rw = 72, rh = 44, cr = 8;
+      const rx = n.x - rw/2, ry = n.y - rh/2;
+
+      if (isSel) {
+        ctx.beginPath();
+        ctx.roundRect(rx - 4, ry - 4, rw + 8, rh + 8, cr + 2);
+        ctx.fillStyle = color + '30';
+        ctx.fill();
+      }
+
+      ctx.beginPath();
+      ctx.roundRect(rx, ry, rw, rh, cr);
+      ctx.fillStyle = '#0d1117';
+      ctx.fill();
+      ctx.strokeStyle = isSel ? color : (color + '90');
+      ctx.lineWidth = isSel ? 2.5 : 1.5;
+      ctx.stroke();
+
+      ctx.font = 'bold 11px monospace';
+      ctx.fillStyle = '#f0f6fc';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(n.info.hostname || 'this machine', n.x, n.y - 5);
+      ctx.font = '9px monospace';
+      ctx.fillStyle = '#8b949e';
+      ctx.fillText(n.info.ip || 'local', n.x, n.y + 8);
+    } else {
+      // Circle for radios
+      if (isSel) {
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, NODE_RADIUS + 6, 0, Math.PI * 2);
+        ctx.fillStyle = color + '30';
+        ctx.fill();
+      }
+
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, NODE_RADIUS, 0, Math.PI * 2);
+      ctx.fillStyle = '#0d1117';
+      ctx.fill();
+      ctx.strokeStyle = isSel ? color : (color + '90');
+      ctx.lineWidth = isSel ? 2.5 : 1.5;
+      ctx.stroke();
+
+      ctx.font = 'bold 11px monospace';
+      ctx.fillStyle = '#f0f6fc';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      const label = n.info.hostname
+        ? n.info.hostname.replace('smartradio-', 'sr-')
+        : n.id;
+      ctx.fillText(label, n.x, n.y - 4);
+
+      ctx.font = '9px monospace';
+      ctx.fillStyle = '#8b949e';
+      let sub = '';
+      if (n.info.battery_v != null) sub = n.info.battery_v.toFixed(1) + 'V';
+      else if (n.info.signal != null) sub = n.info.signal + ' dBm';
+      else if (!n.info.reachable) sub = 'offline';
+      ctx.fillText(sub, n.x, n.y + 8);
+    }
+  }
+
+  tick();
+  requestAnimationFrame(draw);
+}
+
+// ---------------------------------------------------------------------------
+// Interaction
+// ---------------------------------------------------------------------------
+
+function nodeAt(x, y) {
+  for (const n of nodes) {
+    if (n.info.is_local) {
+      // Rectangle hit-test
+      if (Math.abs(x - n.x) < 40 && Math.abs(y - n.y) < 26) return n;
+    } else {
+      const dx = n.x - x, dy = n.y - y;
+      if (dx * dx + dy * dy < NODE_RADIUS * NODE_RADIUS) return n;
+    }
+  }
+  return null;
+}
+
+canvas.addEventListener('mousedown', e => {
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left, y = e.clientY - rect.top;
+  const hit = nodeAt(x, y);
+  if (hit) { dragging = hit.id; selected = hit.id; }
+  else { selected = null; }
+  updateSidebar();
+});
+
+canvas.addEventListener('mousemove', e => {
+  const rect = canvas.getBoundingClientRect();
+  mouse.x = e.clientX - rect.left;
+  mouse.y = e.clientY - rect.top;
+  if (dragging) {
+    const n = nodes.find(n => n.id === dragging);
+    if (n) { n.x = mouse.x; n.y = mouse.y; }
+  }
+  canvas.style.cursor = nodeAt(mouse.x, mouse.y) ? 'grab' : 'default';
+});
+
+canvas.addEventListener('mouseup', () => { dragging = null; });
+
+// ---------------------------------------------------------------------------
+// Sidebar
+// ---------------------------------------------------------------------------
+
+function uptimeStr(s) {
+  if (!s) return '?';
+  const d = Math.floor(s / 86400), h = Math.floor((s % 86400) / 3600),
+        m = Math.floor((s % 3600) / 60);
+  let parts = [];
+  if (d) parts.push(d + 'd');
+  if (h) parts.push(h + 'h');
+  parts.push(m + 'm');
+  return parts.join(' ');
+}
+
+function updateSidebar() {
+  // Node cards
+  let nodeHtml = '';
+  for (const n of nodes) {
+    const info = n.info;
+    const sel = n.id === selected ? ' selected' : '';
+    const hn = info.hostname || n.id;
+    nodeHtml += `<div class="node-card${sel}" onclick="selected='${n.id}';updateSidebar()">`;
+    nodeHtml += `<div class="name">${hn}`;
+    if (info.is_local) nodeHtml += ` <span class="badge" style="background:#6e5c2e;color:#fff">this machine</span>`;
+    else if (!info.reachable) nodeHtml += ` <span class="badge gray">offline</span>`;
+    nodeHtml += `</div>`;
+    if (info.ip) nodeHtml += `<div class="field">IP: <span>${info.ip}</span></div>`;
+    if (info.dl_interface) nodeHtml += `<div class="field">Interface: <span>${info.dl_interface}</span></div>`;
+    if (info.model) nodeHtml += `<div class="field">Model: <span>${info.model}</span></div>`;
+    if (info.firmware) nodeHtml += `<div class="field">FW: <span>${info.firmware}</span></div>`;
+    if (info.uptime) nodeHtml += `<div class="field">Uptime: <span>${uptimeStr(info.uptime)}</span></div>`;
+    if (info.frequency) {
+      let rf = info.frequency + 'MHz';
+      if (info.htmode) rf += ' / ' + info.htmode;
+      if (info.channel) rf += ' / ch' + info.channel;
+      nodeHtml += `<div class="field">Radio: <span>${rf}</span></div>`;
+    }
+    if (info.signal != null) {
+      let link = 'Signal: ' + info.signal + 'dBm';
+      if (info.noise != null) link += ' / Noise: ' + info.noise + 'dBm';
+      if (info.signal != null && info.noise != null && info.noise !== 0)
+        link += ' / SNR: ' + (info.signal - info.noise) + 'dB';
+      nodeHtml += `<div class="field">Link: <span>${link}</span></div>`;
+    }
+    if (info.bitrate) nodeHtml += `<div class="field">Rate: <span>${(info.bitrate/1000).toFixed(1)} Mbps</span></div>`;
+    if (info.battery_v != null) {
+      const bc = batteryBadge(info.battery_v);
+      nodeHtml += `<div class="field">Battery: <span class="badge ${bc}">${info.battery_v.toFixed(2)}V</span></div>`;
+    }
+    if (info.temperature != null)
+      nodeHtml += `<div class="field">Temp: <span>${info.temperature}°C</span></div>`;
+    if (info.mem_total) {
+      const pct = Math.round(100 * (1 - info.mem_free / info.mem_total));
+      nodeHtml += `<div class="field">Memory: <span>${pct}% used</span></div>`;
+    }
+    if (info.gps) {
+      const g = info.gps;
+      let gps = (g.latitude || '?') + ', ' + (g.longitude || '?');
+      if (g.altitude) gps += ' alt ' + g.altitude + 'm';
+      nodeHtml += `<div class="field">GPS: <span>${gps}</span></div>`;
+    }
+    if (info.error) nodeHtml += `<div class="field" style="color:#da3633">${info.error}</div>`;
+    nodeHtml += '</div>';
+  }
+  document.getElementById('nodeList').innerHTML = nodeHtml || '<div class="empty">no nodes</div>';
+
+  // Edge cards
+  let edgeHtml = '';
+  for (const e of edges) {
+    edgeHtml += '<div class="edge-info">';
+    edgeHtml += `<div class="label">${e.source} ↔ ${e.target}</div>`;
+    if (e.data.type === 'ethernet') {
+      edgeHtml += `<div class="field">Type: <span>USB-ethernet</span></div>`;
+    } else if (e.data.type === 'direct') {
+      if (e.data.rssi != null) {
+        const c = e.data.rssi > -60 ? 'green' : e.data.rssi > -75 ? 'yellow' : 'red';
+        edgeHtml += `<div class="field">RSSI: <span class="badge ${c}">${e.data.rssi} dBm</span></div>`;
+      }
+      if (e.data.rssi_ant && e.data.rssi_ant.length)
+        edgeHtml += `<div class="field">Antennas: <span>${e.data.rssi_ant.join(' / ')} dBm</span></div>`;
+      if (e.data.mcs != null) edgeHtml += `<div class="field">MCS: <span>${e.data.mcs}</span></div>`;
+      if (e.data.pl_ratio) edgeHtml += `<div class="field">Packet loss: <span>${e.data.pl_ratio}%</span></div>`;
+    } else {
+      if (e.data.tq != null) {
+        const pct = Math.round(e.data.tq * 100 / 255);
+        const c = e.data.tq > 200 ? 'green' : e.data.tq > 128 ? 'yellow' : 'red';
+        edgeHtml += `<div class="field">TQ: <span class="badge ${c}">${pct}% (${e.data.tq}/255)</span></div>`;
+      }
+      if (e.data.hop_status) edgeHtml += `<div class="field">Hop: <span>${e.data.hop_status}</span></div>`;
+      if (e.data.last_seen_ms != null) edgeHtml += `<div class="field">Last seen: <span>${(e.data.last_seen_ms/1000).toFixed(1)}s ago</span></div>`;
+    }
+    edgeHtml += '</div>';
+  }
+  document.getElementById('edgeList').innerHTML = edgeHtml || '<div class="empty">no links</div>';
+}
+
+// ---------------------------------------------------------------------------
+// Refresh controls
+// ---------------------------------------------------------------------------
+
+let refreshInterval = REFRESH_INTERVAL;
+let autoRefresh = true;
+let refreshTimer = null;
+let fetching = false;
+
+function togglePause() {
+  autoRefresh = !autoRefresh;
+  const btn = document.getElementById('btnPause');
+  btn.textContent = autoRefresh ? 'Auto' : 'Paused';
+  btn.classList.toggle('active', autoRefresh);
+  scheduleRefresh();
+}
+
+function changeInterval(val) {
+  refreshInterval = parseInt(val);
+  scheduleRefresh();
+}
+
+function manualRefresh() {
+  fetchData();
+}
+
+function scheduleRefresh() {
+  if (refreshTimer) clearInterval(refreshTimer);
+  if (autoRefresh) {
+    refreshTimer = setInterval(fetchData, refreshInterval * 1000);
+  }
+}
+
+// Set initial dropdown to match server-side default
+document.getElementById('selInterval').value = String(refreshInterval);
+document.getElementById('btnPause').classList.add('active');
+
+// ---------------------------------------------------------------------------
+// Data fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchData() {
+  if (fetching) return;
+  fetching = true;
+  document.getElementById('btnRefresh').textContent = '...';
+  try {
+    const resp = await fetch('/api/topology');
+    const data = await resp.json();
+
+    const cw = W / devicePixelRatio, ch = H / devicePixelRatio;
+
+    // Merge nodes — keep positions for existing ones
+    const oldMap = {};
+    for (const n of nodes) oldMap[n.id] = n;
+
+    const newNodes = [];
+    for (const info of data.nodes) {
+      const id = info.name;
+      if (oldMap[id]) {
+        oldMap[id].info = info;
+        newNodes.push(oldMap[id]);
+      } else {
+        const angle = newNodes.length * 2.4;
+        const r = 60 + newNodes.length * 30;
+        newNodes.push({
+          id, info,
+          x: cw / 2 + r * Math.cos(angle),
+          y: ch / 2 + r * Math.sin(angle),
+          vx: 0, vy: 0,
+        });
+      }
+    }
+    nodes = newNodes;
+
+    edges = data.edges.map(e => ({
+      source: e.from, target: e.to, data: e,
+    }));
+
+    const age = (Date.now() / 1000 - data.ts);
+    const dot = document.getElementById('statusDot');
+    const txt = document.getElementById('statusText');
+    if (age < refreshInterval * 2) {
+      dot.className = 'dot live';
+      txt.textContent = `live · ${nodes.length} node(s) · ${edges.length} link(s)`;
+    } else {
+      dot.className = 'dot stale';
+      txt.textContent = `stale (${Math.round(age)}s ago)`;
+    }
+
+    updateSidebar();
+  } catch (e) {
+    document.getElementById('statusDot').className = 'dot stale';
+    document.getElementById('statusText').textContent = 'fetch error: ' + e;
+  } finally {
+    fetching = false;
+    document.getElementById('btnRefresh').textContent = 'Refresh';
+  }
+}
+
+fetchData();
+scheduleRefresh();
+requestAnimationFrame(draw);
+</script>
+</body>
+</html>"""
+
+
+# ---------------------------------------------------------------------------
+# HTTP server
+# ---------------------------------------------------------------------------
+
+class Handler(BaseHTTPRequestHandler):
+    state = None  # set in main
+
+    def log_message(self, fmt, *args):
+        pass  # quiet
+
+    def do_GET(self):
+        if self.path == '/api/topology':
+            data = self.state.get()
+            body = json.dumps(data).encode()
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', len(body))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path in ('/', '/index.html'):
+            body = HTML_PAGE.replace(
+                'REFRESH_INTERVAL', str(self.refresh_interval),
+            ).encode()
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html')
+            self.send_header('Content-Length', len(body))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(404)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Doodle Labs mesh topology visualizer')
+    parser.add_argument('--port', type=int, default=8780)
+    parser.add_argument('--refresh', type=int, default=5,
+                        help='poll interval in seconds')
+    parser.add_argument('--no-open', action='store_true',
+                        help="don't auto-open browser")
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).resolve().parent
+    topology = script_dir.parent / 'config' / 'topology.yaml'
+    if not topology.exists():
+        print(f"topology.yaml not found at {topology}", file=sys.stderr)
+        sys.exit(1)
+
+    state = TopologyState(str(topology))
+
+    # Initial poll before serving
+    print(f"Querying radios from {topology.name}...")
+    state.poll()
+    data = state.get()
+    print(f"  Found {len(data['nodes'])} node(s), {len(data['edges'])} link(s)")
+
+    # Start background poller
+    t = threading.Thread(target=poller_loop, args=(state, args.refresh),
+                         daemon=True)
+    t.start()
+
+    # Start HTTP server
+    Handler.state = state
+    Handler.refresh_interval = args.refresh
+    server = HTTPServer(('127.0.0.1', args.port), Handler)
+
+    url = f'http://localhost:{args.port}'
+    print(f"Serving at {url}  (refresh every {args.refresh}s)")
+    print("Press Ctrl+C to stop.")
+
+    if not args.no_open:
+        webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+
+
+if __name__ == '__main__':
+    main()

--- a/network_diagnostics/scripts/doodlelabs_status.sh
+++ b/network_diagnostics/scripts/doodlelabs_status.sh
@@ -1,0 +1,899 @@
+#!/usr/bin/env bash
+# doodlelabs_status.sh — Doodle Labs Mesh Rider radio status via JSON-RPC (ubus) API
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOPOLOGY="${SCRIPT_DIR}/../config/topology.yaml"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'; BOLD='\033[1m'; DIM='\033[2m'
+
+# ---------------------------------------------------------------------------
+# Topology helpers
+# ---------------------------------------------------------------------------
+
+get_doodlelabs_interface() {
+    python3 -c "
+import subprocess
+result = subprocess.run(['ip', '-o', 'addr', 'show'], capture_output=True, text=True)
+for line in result.stdout.strip().split('\n'):
+    if '192.168.153.' in line:
+        print(line.split()[1])
+        break
+"
+}
+
+get_radio_entries() {
+    python3 -c "
+import yaml
+with open('${TOPOLOGY}') as f:
+    data = yaml.safe_load(f)
+radios = data.get('doodlelabs_radios', {}).get('radios', {})
+for name, info in sorted(radios.items()):
+    ip = info.get('ip', '') or ''
+    if ip:
+        user = info.get('user', 'user')
+        password = info.get('password', 'DoodleSmartRadio')
+        print(f'{name}|{ip}|{user}|{password}')
+"
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_status() {
+    echo -e "${BOLD}=== Doodle Labs Radio Status ===${NC}"
+    echo ""
+
+    # Check for local interface
+    local iface
+    iface=$(get_doodlelabs_interface) || true
+    if [[ -n "$iface" ]]; then
+        echo -e "Doodle Labs interface: ${CYAN}${iface}${NC}"
+    else
+        echo -e "${YELLOW}No local Doodle Labs interface detected (no 192.168.153.x address).${NC}"
+    fi
+    echo ""
+
+    echo -e "${BOLD}Radio status (JSON-RPC API):${NC}"
+    echo ""
+
+    while IFS='|' read -r name ip user password; do
+        [[ -z "$name" ]] && continue
+        [[ -z "$ip" ]] && continue
+
+        echo -ne "  Querying ${name} (${ip})... "
+
+        local api_result
+        api_result=$(DL_IP="$ip" DL_USER="$user" DL_PASS="$password" python3 << 'PYEOF'
+import urllib.request, json, ssl, time, sys, os
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+ip = os.environ["DL_IP"]
+user = os.environ["DL_USER"]
+password = os.environ["DL_PASS"]
+
+base = f"https://{ip}/ubus"
+null_token = "00000000000000000000000000000000"
+
+def rpc(token, obj, method, args=None):
+    if args is None:
+        args = {}
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "call",
+        "params": [token, obj, method, args]
+    }).encode()
+    req = urllib.request.Request(base, data=payload,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
+        data = json.loads(resp.read())
+    result = data.get("result", [])
+    if len(result) >= 2:
+        return result[0], result[1]
+    elif len(result) == 1:
+        return result[0], None
+    return -1, None
+
+try:
+    start = time.monotonic()
+
+    code, login_data = rpc(null_token, "session", "login",
+                           {"username": user, "password": password})
+    if code != 0 or not login_data:
+        print(json.dumps({"error": f"login failed (code={code})"}))
+        sys.exit()
+    token = login_data.get("ubus_rpc_session", "")
+    if not token:
+        print(json.dumps({"error": "no session token returned"}))
+        sys.exit()
+
+    out = {}
+
+    code, data = rpc(token, "system", "board", {})
+    if code == 0 and data:
+        out["board"] = data
+
+    code, data = rpc(token, "file", "read",
+                     {"path": "/tmp/linkstate_current.json", "base64": False})
+    if code == 0 and data and data.get("data"):
+        try:
+            out["linkstate"] = json.loads(data["data"])
+        except json.JSONDecodeError:
+            pass
+
+    code, data = rpc(token, "file", "exec",
+                     {"command": "cat", "params": ["/tmp/run/pancake.txt"]})
+    if code == 0 and data and data.get("stdout"):
+        try:
+            out["pancake"] = json.loads(data["stdout"])
+        except json.JSONDecodeError:
+            pass
+
+    gps = {}
+    for field in ["latitude", "longitude", "altitude"]:
+        code, data = rpc(token, "file", "read",
+                         {"path": f"/var/run/gps/{field}"})
+        if code == 0 and data and data.get("data"):
+            gps[field] = data["data"].strip()
+    if gps:
+        out["gps"] = gps
+
+    code, data = rpc(token, "system", "info", {})
+    if code == 0 and data:
+        out["sysinfo"] = data
+
+    code, data = rpc(token, "iwinfo", "info", {"device": "wlan0"})
+    if code == 0 and data:
+        out["iwinfo"] = data
+
+    elapsed_ms = (time.monotonic() - start) * 1000
+    out["_response_ms"] = elapsed_ms
+    print(json.dumps(out))
+
+except Exception as e:
+    print(json.dumps({"error": str(e)}))
+PYEOF
+)
+
+        # Display results — pass JSON via env var to avoid stdin/heredoc conflict
+        DL_JSON="$api_result" python3 << 'PYEOF'
+import json, sys, os
+
+raw = os.environ.get("DL_JSON", "").strip()
+if not raw:
+    print('\033[0;31mno response\033[0m\n')
+    sys.exit()
+
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    print(f'\033[0;31mparse error\033[0m\n')
+    sys.exit()
+
+if 'error' in data:
+    print(f'\033[0;31mFAILED\033[0m: {data["error"]}\n')
+    sys.exit()
+
+resp_ms = data.get('_response_ms', 0)
+print(f'\033[0;32mOK\033[0m ({resp_ms:.0f}ms)')
+
+# Board info
+board = data.get('board', {})
+hostname = board.get('hostname', '?')
+model = board.get('model', '?')
+release = board.get('release', {})
+firmware = release.get('description', release.get('version', '?'))
+print(f'    Hostname: {hostname}')
+print(f'    Model:    {model}')
+print(f'    Firmware: {firmware}')
+
+# System info (uptime, memory)
+sysinfo = data.get('sysinfo', {})
+if sysinfo:
+    uptime_s = sysinfo.get('uptime', 0)
+    days = uptime_s // 86400
+    hours = (uptime_s % 86400) // 3600
+    mins = (uptime_s % 3600) // 60
+    parts = []
+    if days: parts.append(f'{days}d')
+    if hours: parts.append(f'{hours}h')
+    parts.append(f'{mins}m')
+    print(f'    Uptime:   {" ".join(parts)}')
+
+    mem = sysinfo.get('memory', {})
+    total = mem.get('total', 0)
+    free = mem.get('free', 0) + mem.get('buffered', 0) + mem.get('cached', 0)
+    if total > 0:
+        used_pct = 100 * (1 - free / total)
+        print(f'    Memory:   {used_pct:.0f}% used ({free // 1024 // 1024}MB free / {total // 1024 // 1024}MB)')
+
+# Pancake (wearable: battery voltage + temperature)
+pancake = data.get('pancake')
+if pancake:
+    temp = pancake.get('Temperature', pancake.get('temperature'))
+    vin = pancake.get('VIN VOLTAGE', pancake.get('vin_voltage'))
+    parts = []
+    if temp is not None:
+        temp_val = float(temp)
+        if temp_val > 70:
+            tc = '\033[0;31m'
+        elif temp_val > 55:
+            tc = '\033[1;33m'
+        else:
+            tc = '\033[0;32m'
+        parts.append(f'Temp: {tc}{temp_val:.0f}C\033[0m')
+    if vin is not None:
+        volts = float(vin) / 20.2
+        if volts > 7.84:
+            vc = '\033[0;32m'
+        elif volts > 7.39:
+            vc = '\033[1;33m'
+        elif volts > 6.5:
+            vc = '\033[0;31m'
+        else:
+            vc = '\033[0;31m\033[5m'
+        parts.append(f'Battery: {vc}{volts:.2f}V\033[0m')
+    if parts:
+        print(f'    Wearable: {" | ".join(parts)}')
+
+# Wireless info (prefer iwinfo for RF params — linkstate chan_width/noise can be 0)
+iwinfo = data.get('iwinfo', {})
+ls = data.get('linkstate', {})
+if iwinfo:
+    freq = iwinfo.get('frequency')
+    channel = iwinfo.get('channel')
+    txpower = iwinfo.get('txpower')
+    htmode = iwinfo.get('htmode', '')
+    noise = iwinfo.get('noise')
+    signal = iwinfo.get('signal')
+    bitrate = iwinfo.get('bitrate')
+    mode = iwinfo.get('mode')
+
+    parts = []
+    if freq: parts.append(f'{freq}MHz')
+    if channel: parts.append(f'ch{channel}')
+    if htmode: parts.append(htmode)
+    if txpower: parts.append(f'{txpower}dBm TX')
+    if mode: parts.append(mode)
+    if parts:
+        print(f'    Radio:    {" / ".join(parts)}')
+
+    rf_parts = []
+    if signal is not None: rf_parts.append(f'Signal: {signal}dBm')
+    if noise is not None: rf_parts.append(f'Noise: {noise}dBm')
+    if signal is not None and noise is not None and noise != 0:
+        snr = signal - noise
+        rf_parts.append(f'SNR: {snr}dB')
+    if bitrate: rf_parts.append(f'Rate: {bitrate/1000:.1f}Mbps')
+    activity = ls.get('activity') if ls else None
+    if activity is not None: rf_parts.append(f'Activity: {activity}%')
+    if rf_parts:
+        print(f'    Link:     {" / ".join(rf_parts)}')
+
+    # Connected peers (from linkstate)
+    sta_stats = ls.get('sta_stats', [])
+    if sta_stats:
+        print(f'    Peers ({len(sta_stats)}):')
+        for peer in sta_stats:
+            mac = peer.get('mac', '?')
+            rssi = peer.get('rssi', '?')
+            rssi_ant = peer.get('rssi_ant', [])
+            pl = peer.get('pl_ratio', 0)
+            mcs = peer.get('mcs', '?')
+            rssi_val = float(rssi) if rssi != '?' else -999
+            if rssi_val > -60:
+                rc = '\033[0;32m'
+            elif rssi_val > -75:
+                rc = '\033[1;33m'
+            else:
+                rc = '\033[0;31m'
+            ant_str = f' (ant: {"/".join(str(a) for a in rssi_ant)})' if rssi_ant else ''
+            pl_str = f'  PL: {pl}%' if pl and float(pl) > 0 else ''
+            print(f'      {mac}  RSSI: {rc}{rssi}dBm{ant_str}\033[0m  MCS: {mcs}{pl_str}')
+
+    # Mesh nodes
+    mesh_stats = ls.get('mesh_stats', [])
+    if mesh_stats:
+        print(f'    Mesh ({len(mesh_stats)} nodes):')
+        for node in mesh_stats:
+            orig = node.get('orig_address', '?')
+            tq = node.get('tq', '?')
+            hop = node.get('hop_status', '?')
+            seen = node.get('last_seen_msecs', '?')
+            tq_val = int(tq) if tq != '?' else 0
+            tq_pct = tq_val * 100 // 255 if tq_val else 0
+            if tq_val > 200:
+                tc = '\033[0;32m'
+            elif tq_val > 128:
+                tc = '\033[1;33m'
+            else:
+                tc = '\033[0;31m'
+            print(f'      {orig}  TQ: {tc}{tq_pct}%\033[0m ({tq}/255)  {hop}  seen {seen}ms ago')
+
+# GPS
+gps = data.get('gps', {})
+if gps:
+    lat = gps.get('latitude', '')
+    lon = gps.get('longitude', '')
+    alt = gps.get('altitude', '')
+    if lat and lon and lat != '0' and lon != '0':
+        parts = [f'{lat}, {lon}']
+        if alt:
+            parts.append(f'alt {alt}m')
+        print(f'    GPS:      {" / ".join(parts)}')
+
+print()
+PYEOF
+
+    done < <(get_radio_entries)
+}
+
+cmd_topology() {
+    echo -e "${BOLD}=== Doodle Labs Mesh Topology ===${NC}"
+    echo ""
+
+    DL_TOPOLOGY="$TOPOLOGY" python3 << 'PYEOF'
+import yaml, urllib.request, json, ssl, sys, os
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+with open(os.environ["DL_TOPOLOGY"]) as f:
+    data = yaml.safe_load(f)
+
+radios = data.get('doodlelabs_radios', {}).get('radios', {})
+null_token = "00000000000000000000000000000000"
+
+def rpc(ip, token, obj, method, args=None):
+    if args is None:
+        args = {}
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "call",
+        "params": [token, obj, method, args]
+    }).encode()
+    req = urllib.request.Request(f"https://{ip}/ubus", data=payload,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
+        result = json.loads(resp.read())
+    r = result.get("result", [])
+    if len(r) >= 2:
+        return r[0], r[1]
+    return -1, None
+
+def login(ip, user, password):
+    code, data = rpc(ip, null_token, "session", "login",
+                     {"username": user, "password": password})
+    if code == 0 and data:
+        return data.get("ubus_rpc_session", "")
+    return ""
+
+all_nodes = {}
+
+for name, info in sorted(radios.items()):
+    ip = info.get('ip', '')
+    if not ip:
+        continue
+    user = info.get('user', 'user')
+    password = info.get('password', 'DoodleSmartRadio')
+
+    try:
+        token = login(ip, user, password)
+        if not token:
+            print(f'  \033[1;33m{name}: auth failed\033[0m')
+            continue
+
+        code, data = rpc(ip, token, "file", "read",
+                         {"path": "/tmp/linkstate_current.json", "base64": False})
+        if code != 0 or not data or not data.get("data"):
+            print(f'  \033[1;33m{name}: no linkstate\033[0m')
+            continue
+
+        ls = json.loads(data["data"])
+
+        code, board = rpc(ip, token, "system", "board", {})
+        hostname = board.get("hostname", name) if code == 0 and board else name
+
+        mesh_stats = ls.get("mesh_stats", [])
+        sta_stats = ls.get("sta_stats", [])
+
+        peers = []
+        for peer in sta_stats:
+            peers.append({
+                "mac": peer.get("mac", "?"),
+                "rssi": peer.get("rssi", "?"),
+            })
+
+        all_nodes[name] = {
+            "hostname": hostname,
+            "ip": ip,
+            "mesh": mesh_stats,
+            "peers": peers,
+            "noise": ls.get("noise"),
+            "freq": ls.get("oper_freq"),
+        }
+
+    except Exception as e:
+        print(f'  \033[1;33m{name}: {e}\033[0m')
+
+if not all_nodes:
+    print("  No radios reachable.")
+    sys.exit()
+
+print("Reachable radios:")
+for name, info in sorted(all_nodes.items()):
+    freq = info.get("freq", "?")
+    noise = info.get("noise", "?")
+    print(f'  {name} ({info["hostname"]}) at {info["ip"]}  freq={freq}MHz noise={noise}dBm')
+print()
+
+print("Direct peers (L1 links):")
+for name, info in sorted(all_nodes.items()):
+    peers = info.get("peers", [])
+    if peers:
+        for p in peers:
+            print(f'  {name} <-> {p["mac"]}  RSSI: {p["rssi"]}dBm')
+    else:
+        print(f'  {name}: no direct peers')
+print()
+
+print("Mesh topology (batman-adv):")
+for name, info in sorted(all_nodes.items()):
+    mesh = info.get("mesh", [])
+    if mesh:
+        print(f'  From {name}:')
+        for node in mesh:
+            orig = node.get("orig_address", "?")
+            tq = node.get("tq", "?")
+            hop = node.get("hop_status", "?")
+            tq_val = int(tq) if tq != '?' else 0
+            tq_pct = tq_val * 100 // 255 if tq_val else 0
+            print(f'    {orig}  TQ={tq_pct}% ({tq}/255)  {hop}')
+    else:
+        print(f'  From {name}: no mesh nodes')
+PYEOF
+}
+
+cmd_linkstate() {
+    echo -e "${BOLD}=== Doodle Labs Live Link State ===${NC}"
+    echo ""
+
+    local interval="${1:-5}"
+    echo -e "Polling every ${interval}s. Press Ctrl+C to stop."
+    echo ""
+
+    trap 'echo -e "\n${NC}Stopped."; exit 0' INT
+
+    while true; do
+        local ts
+        ts=$(date '+%H:%M:%S')
+
+        while IFS='|' read -r name ip user password; do
+            [[ -z "$name" ]] && continue
+            [[ -z "$ip" ]] && continue
+
+            DL_IP="$ip" DL_USER="$user" DL_PASS="$password" DL_NAME="$name" DL_TS="$ts" python3 << 'PYEOF'
+import urllib.request, json, ssl, sys, os
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+ip = os.environ["DL_IP"]
+user = os.environ["DL_USER"]
+password = os.environ["DL_PASS"]
+name = os.environ["DL_NAME"]
+ts = os.environ["DL_TS"]
+
+base = f"https://{ip}/ubus"
+null_token = "00000000000000000000000000000000"
+
+def rpc(token, obj, method, args=None):
+    if args is None:
+        args = {}
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "call",
+        "params": [token, obj, method, args]
+    }).encode()
+    req = urllib.request.Request(base, data=payload,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
+        data = json.loads(resp.read())
+    result = data.get("result", [])
+    if len(result) >= 2:
+        return result[0], result[1]
+    return -1, None
+
+try:
+    code, login_data = rpc(null_token, "session", "login",
+                           {"username": user, "password": password})
+    if code != 0 or not login_data:
+        print(f'[{ts}] {name}: \033[0;31mauth failed\033[0m')
+        sys.exit()
+    token = login_data["ubus_rpc_session"]
+
+    code, data = rpc(token, "file", "read",
+                     {"path": "/tmp/linkstate_current.json", "base64": False})
+    if code != 0 or not data or not data.get("data"):
+        print(f'[{ts}] {name}: \033[0;31mno linkstate\033[0m')
+        sys.exit()
+
+    ls = json.loads(data["data"])
+    noise = ls.get("noise", "?")
+    activity = ls.get("activity", "?")
+
+    peers = ls.get("sta_stats", [])
+    peer_parts = []
+    for p in peers:
+        mac = p.get("mac", "?")[-8:]
+        rssi = p.get("rssi", "?")
+        mcs = p.get("mcs", "?")
+        peer_parts.append(f'{mac}:{rssi}dBm/MCS{mcs}')
+
+    mesh = ls.get("mesh_stats", [])
+
+    print(f'[{ts}] {name}: noise={noise}dBm activity={activity}% '
+          f'peers=[{", ".join(peer_parts)}] mesh_nodes={len(mesh)}')
+
+except Exception as e:
+    print(f'[{ts}] {name}: \033[0;31m{e}\033[0m')
+PYEOF
+
+        done < <(get_radio_entries)
+
+        sleep "$interval"
+    done
+}
+
+cmd_battery_watch() {
+    local threshold="${1:-7.0}"
+    local interval="${2:-30}"
+    echo -e "${BOLD}=== Doodle Labs Battery Watch ===${NC} (threshold: ${threshold}V, interval: ${interval}s)"
+    echo -e "Voltage thresholds: >7.84V ${GREEN}green${NC}, 7.39-7.84V ${YELLOW}yellow${NC}, 6.5-7.39V ${RED}red${NC}"
+    echo -e "Press Ctrl+C to stop."
+    echo ""
+
+    trap 'echo -e "\n${NC}Stopped."; exit 0' INT
+
+    while true; do
+        local ts
+        ts=$(date '+%H:%M:%S')
+
+        while IFS='|' read -r name ip user password; do
+            [[ -z "$name" ]] && continue
+            [[ -z "$ip" ]] && continue
+
+            DL_IP="$ip" DL_USER="$user" DL_PASS="$password" DL_NAME="$name" DL_TS="$ts" DL_THRESHOLD="$threshold" python3 << 'PYEOF'
+import urllib.request, json, ssl, sys, os
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+ip = os.environ["DL_IP"]
+user = os.environ["DL_USER"]
+password = os.environ["DL_PASS"]
+name = os.environ["DL_NAME"]
+ts = os.environ["DL_TS"]
+threshold = float(os.environ["DL_THRESHOLD"])
+
+base = f"https://{ip}/ubus"
+null_token = "00000000000000000000000000000000"
+
+def rpc(token, obj, method, args=None):
+    if args is None:
+        args = {}
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "call",
+        "params": [token, obj, method, args]
+    }).encode()
+    req = urllib.request.Request(base, data=payload,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
+        data = json.loads(resp.read())
+    result = data.get("result", [])
+    if len(result) >= 2:
+        return result[0], result[1]
+    return -1, None
+
+try:
+    code, login_data = rpc(null_token, "session", "login",
+                           {"username": user, "password": password})
+    if code != 0 or not login_data:
+        print(f'[{ts}] {name}: \033[0;31munreachable\033[0m')
+        sys.exit()
+    token = login_data["ubus_rpc_session"]
+
+    code, data = rpc(token, "file", "exec",
+                     {"command": "cat", "params": ["/tmp/run/pancake.txt"]})
+    if code != 0 or not data or not data.get("stdout"):
+        print(f'[{ts}] {name}: \033[1;33mno pancake data (not a wearable?)\033[0m')
+        sys.exit()
+
+    pancake = json.loads(data["stdout"])
+    vin = pancake.get("VIN VOLTAGE", pancake.get("vin_voltage"))
+    temp = pancake.get("Temperature", pancake.get("temperature"))
+
+    if vin is not None:
+        volts = float(vin) / 20.2
+        temp_str = f'  Temp: {temp}C' if temp is not None else ''
+
+        if volts <= threshold:
+            print(f'[{ts}] \033[0;31m\033[1mALERT\033[0m {name}: battery \033[0;31m{volts:.2f}V\033[0m{temp_str} \a')
+        elif volts <= 7.39:
+            print(f'[{ts}] {name}: battery \033[0;31m{volts:.2f}V\033[0m{temp_str}')
+        elif volts <= 7.84:
+            print(f'[{ts}] {name}: battery \033[1;33m{volts:.2f}V\033[0m{temp_str}')
+        else:
+            print(f'[{ts}] {name}: battery \033[0;32m{volts:.2f}V\033[0m{temp_str}')
+    else:
+        print(f'[{ts}] {name}: \033[1;33mno voltage data\033[0m')
+
+except Exception as e:
+    print(f'[{ts}] {name}: \033[0;31m{e}\033[0m')
+PYEOF
+
+        done < <(get_radio_entries)
+
+        sleep "$interval"
+    done
+}
+
+cmd_radio_config() {
+    echo -e "${BOLD}=== Doodle Labs Radio Configuration ===${NC}"
+    echo ""
+
+    while IFS='|' read -r name ip user password; do
+        [[ -z "$name" ]] && continue
+        [[ -z "$ip" ]] && continue
+
+        echo -ne "  ${name} (${ip}): "
+
+        DL_IP="$ip" DL_USER="$user" DL_PASS="$password" python3 << 'PYEOF'
+import urllib.request, json, ssl, sys, os
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+ip = os.environ["DL_IP"]
+user = os.environ["DL_USER"]
+password = os.environ["DL_PASS"]
+
+base = f"https://{ip}/ubus"
+null_token = "00000000000000000000000000000000"
+
+def rpc(token, obj, method, args=None):
+    if args is None:
+        args = {}
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "call",
+        "params": [token, obj, method, args]
+    }).encode()
+    req = urllib.request.Request(base, data=payload,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
+        data = json.loads(resp.read())
+    result = data.get("result", [])
+    if len(result) >= 2:
+        return result[0], result[1]
+    return -1, None
+
+try:
+    code, login_data = rpc(null_token, "session", "login",
+                           {"username": user, "password": password})
+    if code != 0 or not login_data:
+        print('\033[0;31mauth failed\033[0m')
+        sys.exit()
+    token = login_data["ubus_rpc_session"]
+
+    print()
+
+    code, board = rpc(token, "system", "board", {})
+    if code == 0 and board:
+        print(f'    Hostname:   {board.get("hostname", "?")}')
+        print(f'    Model:      {board.get("model", "?")}')
+        release = board.get("release", {})
+        print(f'    Firmware:   {release.get("description", release.get("version", "?"))}')
+        print(f'    Kernel:     {board.get("kernel", "?")}')
+
+    code, info = rpc(token, "system", "info", {})
+    if code == 0 and info:
+        uptime = info.get("uptime", 0)
+        d, h, m = uptime // 86400, (uptime % 86400) // 3600, (uptime % 3600) // 60
+        parts = []
+        if d: parts.append(f'{d}d')
+        if h: parts.append(f'{h}h')
+        parts.append(f'{m}m')
+        print(f'    Uptime:     {" ".join(parts)}')
+
+    code, iw = rpc(token, "iwinfo", "info", {"device": "wlan0"})
+    if code == 0 and iw:
+        print(f'    SSID:       {iw.get("ssid", "?")}')
+        print(f'    Mode:       {iw.get("mode", "?")}')
+        print(f'    Frequency:  {iw.get("frequency", "?")} MHz')
+        print(f'    Channel:    {iw.get("channel", "?")}')
+        print(f'    TX Power:   {iw.get("txpower", "?")} dBm')
+        print(f'    Bitrate:    {iw.get("bitrate", "?")}')
+        enc = iw.get("encryption", {})
+        if enc:
+            print(f'    Encryption: {enc.get("description", enc.get("enabled", "?"))}')
+        hwmodes = iw.get("hwmodes", [])
+        if hwmodes:
+            print(f'    HW Modes:   {", ".join(hwmodes)}')
+
+    code, data = rpc(token, "file", "read",
+                     {"path": "/tmp/linkstate_current.json", "base64": False})
+    if code == 0 and data and data.get("data"):
+        ls = json.loads(data["data"])
+        print(f'    Chan Width: {ls.get("chan_width", "?")} MHz')
+        print(f'    Noise:      {ls.get("noise", "?")} dBm')
+        print(f'    LNA:        {ls.get("lna_status", "?")}')
+
+    code, data = rpc(token, "file", "exec",
+                     {"command": "cat", "params": ["/tmp/run/pancake.txt"]})
+    if code == 0 and data and data.get("stdout"):
+        try:
+            pancake = json.loads(data["stdout"])
+            if pancake:
+                print(f'    Wearable HW:')
+                for k, v in pancake.items():
+                    print(f'      {k}: {v}')
+        except json.JSONDecodeError:
+            pass
+
+    print()
+
+except Exception as e:
+    print(f'\033[0;31mFAILED: {e}\033[0m')
+    print()
+PYEOF
+
+    done < <(get_radio_entries)
+}
+
+cmd_ssh() {
+    local target="${1:-}"
+    if [[ -z "$target" ]]; then
+        local first
+        first=$(get_radio_entries | head -1)
+        if [[ -z "$first" ]]; then
+            echo -e "${RED}No radios configured in topology.yaml${NC}"
+            return 1
+        fi
+        target=$(echo "$first" | cut -d'|' -f2)
+    fi
+
+    echo -e "${BOLD}Connecting to ${target}...${NC}"
+    echo -e "${DIM}(default creds: user / DoodleSmartRadio)${NC}"
+    ssh -o StrictHostKeyChecking=no -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa "root@${target}"
+}
+
+cmd_discover() {
+    local iface
+    iface=$(get_doodlelabs_interface)
+    if [[ -z "$iface" ]]; then
+        echo -e "${RED}Could not find Doodle Labs interface (no 192.168.153.x address).${NC}"
+        return 1
+    fi
+
+    echo -e "${BOLD}=== Doodle Labs Radio Discovery ===${NC}"
+    echo -e "Interface: ${CYAN}${iface}${NC}"
+    echo ""
+
+    echo -ne "  192.168.153.1 (config IP): "
+    if ping -c 1 -W 2 192.168.153.1 &>/dev/null; then
+        local result
+        result=$(python3 << 'PYEOF' 2>/dev/null
+import urllib.request, json, ssl
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+null_token = "00000000000000000000000000000000"
+base = "https://192.168.153.1/ubus"
+
+for username in ["user", "root"]:
+    try:
+        payload = json.dumps({
+            "jsonrpc": "2.0", "id": 1, "method": "call",
+            "params": [null_token, "session", "login",
+                       {"username": username, "password": "DoodleSmartRadio"}]
+        }).encode()
+        req = urllib.request.Request(base, data=payload,
+                                     headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
+            data = json.loads(resp.read())
+        result = data.get("result", [])
+        if len(result) >= 2 and result[0] == 0:
+            token = result[1]["ubus_rpc_session"]
+            payload = json.dumps({
+                "jsonrpc": "2.0", "id": 2, "method": "call",
+                "params": [token, "system", "board", {}]
+            }).encode()
+            req = urllib.request.Request(base, data=payload,
+                                         headers={"Content-Type": "application/json"})
+            with urllib.request.urlopen(req, timeout=5, context=ctx) as resp:
+                data = json.loads(resp.read())
+            result = data.get("result", [])
+            if len(result) >= 2 and result[1]:
+                board = result[1]
+                hostname = board.get("hostname", "?")
+                model = board.get("model", "?")
+                rel = board.get("release", {}).get("version", "?")
+                print(f"FOUND  {hostname} / {model} / fw {rel} (login: {username})")
+                break
+    except:
+        continue
+else:
+    print("reachable but login failed")
+PYEOF
+)
+        if [[ -n "$result" ]]; then
+            echo -e "${GREEN}${result}${NC}"
+        else
+            echo -e "${YELLOW}reachable but no API response${NC}"
+        fi
+    else
+        echo -e "${RED}unreachable${NC}"
+    fi
+
+    echo ""
+    echo "Checking ARP table for 10.223.x.x mesh entries..."
+    local found=0
+    while IFS= read -r line; do
+        local mesh_ip
+        mesh_ip=$(echo "$line" | awk '{print $1}')
+        [[ -z "$mesh_ip" ]] && continue
+        echo -ne "  ${mesh_ip}: "
+        if ping -c 1 -W 1 "$mesh_ip" &>/dev/null; then
+            echo -e "${GREEN}reachable${NC}"
+            ((found++))
+        else
+            echo -e "${DIM}stale ARP entry${NC}"
+        fi
+    done < <(ip neigh show 2>/dev/null | grep '10.223' | grep -v FAILED)
+
+    if [[ $found -eq 0 ]]; then
+        echo -e "${DIM}No mesh IPs found in ARP table.${NC}"
+        echo -e "Try: ${CYAN}ping 10.223.255.255${NC} to trigger mesh discovery."
+    fi
+}
+
+usage() {
+    echo "Usage: $(basename "$0") <command>"
+    echo ""
+    echo "Commands:"
+    echo "  status                    Query all radios (firmware, signal, mesh, battery)"
+    echo "  topology                  Show mesh routing topology (batman-adv)"
+    echo "  linkstate [interval]      Live link state monitor (default: 5s)"
+    echo "  discover                  Detect radios on the network"
+    echo "  battery-watch [thr] [int] Monitor battery voltage (threshold V, interval sec)"
+    echo "  radio-config              Show detailed radio configuration"
+    echo "  ssh [ip]                  SSH to a radio (default: first in topology)"
+    echo ""
+    echo "JSON-RPC API endpoint: https://<ip>/ubus (OpenWrt ubus)"
+    echo "Default credentials: user / DoodleSmartRadio"
+    echo ""
+    echo "Setup:"
+    echo "  1. Connect via USB-ethernet (radio appears at 192.168.153.1)"
+    echo "  2. Add radio to topology.yaml under doodlelabs_radios.radios"
+    echo "  3. Run 'status' to query the radio"
+}
+
+case "${1:-}" in
+    status)         cmd_status ;;
+    topology)       cmd_topology ;;
+    linkstate)      cmd_linkstate "${2:-5}" ;;
+    discover)       cmd_discover ;;
+    battery-watch)  cmd_battery_watch "${2:-7.0}" "${3:-30}" ;;
+    radio-config)   cmd_radio_config ;;
+    ssh)            cmd_ssh "${2:-}" ;;
+    -h|--help)      usage ;;
+    "")             cmd_status ;;
+    *)              echo "Unknown command: $1"; usage; exit 1 ;;
+esac


### PR DESCRIPTION
Adds parallel support for Doodle Labs Mesh Rider radios alongside the existing Silvus monitoring, since the fleet is transitioning to Doodle Labs hardware. Auto-detects the radio type from topology.yaml, with an optional --radio-type CLI override on fleet-adt4.

New diagnostic scripts (network_diagnostics/scripts):
* doodlelabs_status.sh — standalone CLI equivalent to silvus_status.sh, supporting status/topology/discover/linkstate/battery-watch/radio-config/ ssh commands against the HTTPS/ubus API
* doodlelabs_mesh_viz.py — live force-directed mesh topology visualizer served as a local web dashboard (Python stdlib + vis-on-canvas)

Fleet manager integration (dcist_launch_system):
* New helpers in fleet_helpers.py: get_doodlelabs_link_quality, get_doodlelabs_radio_details, check/add_doodlelabs_route, and get_active_radio_type(topology, override) for dispatch
* get_remote_status now accepts doodlelabs_ips/doodlelabs_creds and emits a neutral '---RADIO---' section (backward-compatible with '---SILVUS---' for older remote machines)
* MonitorScreen refresh/check_zenoh/silvus_detail/check_silvus_routes actions dispatch to the correct API based on active radio type; the F4 detail view renders an RSSI matrix from sta_stats plus batman-adv TQ from mesh_stats; route-check help message now also prints a template command when the LOCAL machine has no radio interface
* New --radio-type {auto,silvus,doodlelabs,none} CLI flag plumbed through TuiContext.radio_type_override; default 'auto' infers from whichever *_radios section is populated

topology.yaml:
* New doodlelabs_radios section with user/password/ip per radio
* Fix typo: sequia -> sequoia in machines and docs